### PR TITLE
fix: move completed subagents to Recovery Lounge and hide their edges

### DIFF
--- a/src/components/OfficeStage.tsx
+++ b/src/components/OfficeStage.tsx
@@ -74,6 +74,8 @@ export function OfficeStage({ snapshot }: Props) {
 
   const runLinks = useMemo(() => {
     return snapshot.runs
+      // Hide edges for completed/errored subagents
+      .filter((run) => run.status !== "ok" && run.status !== "error")
       .map((run) => {
         const source = placementById.get(`agent:${run.parentAgentId}`);
         const target = placementById.get(`subagent:${run.runId}`);

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -135,6 +135,10 @@ function layoutPoint(params: {
 
 function classifyRoom(entity: OfficeEntity): string {
   if (entity.kind === "subagent") {
+    // Completed or errored subagents go to Recovery Lounge
+    if (entity.status === "ok" || entity.status === "error") {
+      return "lounge";
+    }
     return "spawn";
   }
   if (entity.status === "active") {


### PR DESCRIPTION
## Summary
- Completed subagents (status: `ok`) now move to **Recovery Lounge** instead of staying in Spawn Lab
- Errored subagents (status: `error`) also go to Recovery Lounge
- Parent-child edges are hidden for completed/errored subagents

## Changes
1. `src/lib/layout.ts`: Updated `classifyRoom()` to check subagent status before assigning to Spawn Lab
2. `src/components/OfficeStage.tsx`: Filter out completed/errored runs from edge rendering

## Before/After
**Before:** Completed subagents stayed in Spawn Lab with visible edges
**After:** Completed subagents move to Recovery Lounge, edges disappear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 완료되거나 오류가 발생한 작업 항목이 워크플로우 연결선에서 제외되어 표시됩니다.
  * 마무리된 작업 항목에 대한 레이아웃 배치 로직이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->