### PR TITLE
feat: add zone rule layout engine for issue #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Web-based visual command center for OpenClaw agents and subagents.
 - Layered stage rendering model (`floor -> wall -> object -> entity -> overlay`)
 - Y-axis depth sort for entities + wall-side occlusion dimming
 - Responsive LOD policy (desktop: full layers, smaller viewport: object/wall detail reduction)
+- Zone rule engine (JSON DSL) with priority routing + room capacity overflow policy
+- Room-level debug overlay (`cap/target/overflow`) for layout diagnostics
 
 ## Data source
 
@@ -53,6 +55,10 @@ Live/demo transition rules:
 Kenney tile coordinates and spacing are resolved from
 `public/assets/kenney/kenney-curation.json` so city/interior tile atlases follow
 one standardized source contract.
+
+Room layout policy is resolved from `public/assets/layout/zone-config.json`.
+The client reloads this config periodically (10s) and recalculates placements,
+so policy edits can be reflected without restarting the app.
 
 You can override the state directory:
 

--- a/public/assets/layout/zone-config.json
+++ b/public/assets/layout/zone-config.json
@@ -1,0 +1,114 @@
+{
+  "version": 1,
+  "priorityOrder": ["status", "role", "parent", "recent"],
+  "recentWindowMs": 300000,
+  "parentAffinityPx": 64,
+  "defaultOverflowZoneId": "ops",
+  "rooms": [
+    {
+      "id": "strategy",
+      "label": "Strategy Room",
+      "shape": "ring",
+      "role": "strategy",
+      "x": 280,
+      "y": 70,
+      "width": 330,
+      "height": 180,
+      "fill": "rgba(47, 106, 140, 0.82)",
+      "border": "#8cd7ff",
+      "capacity": 10,
+      "spacing": { "x": 42, "y": 28 },
+      "anchor": { "x": 0.5, "y": 0.48 },
+      "secondaryZoneId": "ops",
+      "routing": {
+        "statuses": ["active"],
+        "kinds": ["agent"],
+        "recentWeight": 0.2
+      }
+    },
+    {
+      "id": "ops",
+      "label": "Ops Floor",
+      "shape": "grid",
+      "role": "ops",
+      "x": 70,
+      "y": 210,
+      "width": 420,
+      "height": 250,
+      "fill": "rgba(40, 88, 115, 0.85)",
+      "border": "#74d1f8",
+      "capacity": 16,
+      "spacing": { "x": 64, "y": 52 },
+      "anchor": { "x": 0.5, "y": 0.5 },
+      "secondaryZoneId": "build",
+      "routing": {
+        "statuses": ["ok", "offline"],
+        "kinds": ["agent"],
+        "recentWeight": 0.15
+      }
+    },
+    {
+      "id": "build",
+      "label": "Build Pods",
+      "shape": "line",
+      "role": "build",
+      "x": 560,
+      "y": 235,
+      "width": 330,
+      "height": 200,
+      "fill": "rgba(44, 125, 132, 0.84)",
+      "border": "#8cf8dc",
+      "capacity": 12,
+      "spacing": { "x": 56, "y": 36 },
+      "anchor": { "x": 0.5, "y": 0.52 },
+      "secondaryZoneId": "ops",
+      "routing": {
+        "statuses": ["idle"],
+        "kinds": ["agent"],
+        "recentWeight": 0.1
+      }
+    },
+    {
+      "id": "spawn",
+      "label": "Spawn Lab",
+      "shape": "cluster",
+      "role": "spawn",
+      "x": 520,
+      "y": 70,
+      "width": 390,
+      "height": 160,
+      "fill": "rgba(17, 82, 111, 0.82)",
+      "border": "#5ec6ff",
+      "capacity": 14,
+      "spacing": { "x": 48, "y": 30 },
+      "anchor": { "x": 0.54, "y": 0.52 },
+      "secondaryZoneId": "ops",
+      "routing": {
+        "statuses": ["active", "idle"],
+        "kinds": ["subagent"],
+        "recentWeight": 0.35
+      }
+    },
+    {
+      "id": "lounge",
+      "label": "Recovery Lounge",
+      "shape": "cluster",
+      "role": "recovery",
+      "x": 300,
+      "y": 470,
+      "width": 420,
+      "height": 150,
+      "fill": "rgba(13, 97, 120, 0.82)",
+      "border": "#70f2ff",
+      "capacity": 12,
+      "spacing": { "x": 54, "y": 28 },
+      "anchor": { "x": 0.5, "y": 0.52 },
+      "secondaryZoneId": "ops",
+      "routing": {
+        "statuses": ["ok", "error", "offline"],
+        "kinds": ["agent", "subagent"],
+        "recentWeight": 0.25
+      }
+    }
+  ]
+}

--- a/src/App.css
+++ b/src/App.css
@@ -248,6 +248,29 @@ body {
   border: 1px solid rgba(197, 244, 255, 0.35);
 }
 
+.zone-debug {
+  position: absolute;
+  left: 10px;
+  bottom: 8px;
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.zone-debug span {
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-size: 0.66rem;
+  color: rgba(217, 247, 255, 0.92);
+  border: 1px solid rgba(186, 236, 255, 0.32);
+  background: rgba(6, 39, 55, 0.38);
+}
+
+.zone-debug.has-overflow span {
+  border-color: rgba(255, 203, 120, 0.45);
+  color: rgba(255, 239, 196, 0.95);
+}
+
 .office-lines {
   position: absolute;
   inset: 0;

--- a/src/lib/layout.test.ts
+++ b/src/lib/layout.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { buildPlacements } from "./layout";
+import type { OfficeEntity } from "../types/office";
+
+function makeEntity(params: Partial<OfficeEntity> & Pick<OfficeEntity, "id" | "agentId" | "label">): OfficeEntity {
+  return {
+    id: params.id,
+    kind: params.kind ?? "agent",
+    label: params.label,
+    agentId: params.agentId,
+    status: params.status ?? "active",
+    sessions: params.sessions ?? 1,
+    activeSubagents: params.activeSubagents ?? 0,
+    parentAgentId: params.parentAgentId,
+    runId: params.runId,
+    lastUpdatedAt: params.lastUpdatedAt,
+    model: params.model,
+    bubble: params.bubble,
+    task: params.task,
+  };
+}
+
+function toPlacementSnapshot(result: ReturnType<typeof buildPlacements>) {
+  return result.placements
+    .map((placement) => ({
+      id: placement.entity.id,
+      roomId: placement.roomId,
+      targetRoomId: placement.targetRoomId,
+      x: Math.round(placement.x * 1000) / 1000,
+      y: Math.round(placement.y * 1000) / 1000,
+      overflowed: placement.overflowed,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+describe("buildPlacements", () => {
+  it("produces deterministic placement output for identical inputs", () => {
+    const entities: OfficeEntity[] = [
+      makeEntity({ id: "agent-1", agentId: "agent-1", label: "Agent 1", status: "active" }),
+      makeEntity({ id: "agent-2", agentId: "agent-2", label: "Agent 2", status: "idle" }),
+      makeEntity({
+        id: "sub-1",
+        kind: "subagent",
+        agentId: "sub-1",
+        label: "Subagent 1",
+        parentAgentId: "agent-1",
+        status: "active",
+      }),
+      makeEntity({
+        id: "sub-2",
+        kind: "subagent",
+        agentId: "sub-2",
+        label: "Subagent 2",
+        parentAgentId: "agent-1",
+        status: "ok",
+      }),
+    ];
+
+    const first = buildPlacements({ entities, generatedAt: 1_000_000 });
+    const second = buildPlacements({ entities, generatedAt: 1_000_000 });
+
+    expect(toPlacementSnapshot(first)).toEqual(toPlacementSnapshot(second));
+  });
+
+  it("keeps all entities placed even when room capacity overflows", () => {
+    const entities = Array.from({ length: 7 }, (_, index) =>
+      makeEntity({
+        id: `agent-overflow-${index + 1}`,
+        agentId: `agent-overflow-${index + 1}`,
+        label: `Overflow Agent ${index + 1}`,
+        status: "active",
+      }),
+    );
+
+    const result = buildPlacements({
+      entities,
+      generatedAt: 1_000_000,
+      zoneConfig: {
+        rooms: [
+          {
+            id: "strategy",
+            capacity: 1,
+            secondaryZoneId: "ops",
+            routing: { statuses: ["active"], kinds: ["agent"], recentWeight: 0 },
+          },
+          {
+            id: "ops",
+            capacity: 1,
+            secondaryZoneId: "build",
+            routing: { statuses: ["active"], kinds: ["agent"], recentWeight: 0 },
+          },
+          {
+            id: "build",
+            capacity: 1,
+            secondaryZoneId: "spawn",
+            routing: { statuses: ["active"], kinds: ["agent"], recentWeight: 0 },
+          },
+          {
+            id: "spawn",
+            capacity: 1,
+            secondaryZoneId: "lounge",
+            routing: { statuses: ["active"], kinds: ["agent"], recentWeight: 0 },
+          },
+          {
+            id: "lounge",
+            capacity: 1,
+            secondaryZoneId: "ops",
+            routing: { statuses: ["active"], kinds: ["agent"], recentWeight: 0 },
+          },
+        ],
+      },
+    });
+
+    expect(result.placements).toHaveLength(entities.length);
+    expect(result.placements.some((placement) => placement.overflowed)).toBe(true);
+    expect(result.roomDebug.get("strategy")?.overflowOut).toBeGreaterThan(0);
+  });
+
+  it("places subagents near parent agents when parent affinity is enabled", () => {
+    const parent = makeEntity({
+      id: "agent-parent",
+      agentId: "agent-parent",
+      label: "Parent Agent",
+      status: "active",
+    });
+    const child = makeEntity({
+      id: "sub-child",
+      kind: "subagent",
+      agentId: "sub-child",
+      label: "Child Subagent",
+      parentAgentId: "agent-parent",
+      status: "active",
+    });
+
+    const parentAffinityPx = 56;
+    const result = buildPlacements({
+      entities: [parent, child],
+      generatedAt: 1_000_000,
+      zoneConfig: {
+        parentAffinityPx,
+        rooms: [
+          {
+            id: "strategy",
+            routing: {
+              statuses: ["active", "idle", "offline", "ok", "error"],
+              kinds: ["agent", "subagent"],
+              recentWeight: 0
+            },
+          },
+          {
+            id: "ops",
+            routing: {
+              statuses: ["ok"],
+              kinds: ["agent"],
+              recentWeight: 0,
+            },
+          },
+          {
+            id: "build",
+            routing: {
+              statuses: ["idle"],
+              kinds: ["agent"],
+              recentWeight: 0,
+            },
+          },
+          {
+            id: "spawn",
+            routing: {
+              statuses: ["idle"],
+              kinds: ["agent"],
+              recentWeight: 0,
+            },
+          },
+          {
+            id: "lounge",
+            routing: {
+              statuses: ["offline"],
+              kinds: ["agent"],
+              recentWeight: 0,
+            },
+          },
+        ],
+      },
+    });
+
+    const parentPlacement = result.placements.find((placement) => placement.entity.id === parent.id);
+    const childPlacement = result.placements.find((placement) => placement.entity.id === child.id);
+
+    expect(parentPlacement).toBeDefined();
+    expect(childPlacement).toBeDefined();
+    expect(parentPlacement?.roomId).toBe("strategy");
+    expect(childPlacement?.roomId).toBe("strategy");
+
+    const dx = (parentPlacement?.x ?? 0) - (childPlacement?.x ?? 0);
+    const dy = (parentPlacement?.y ?? 0) - (childPlacement?.y ?? 0);
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    expect(distance).toBeLessThanOrEqual(parentAffinityPx * 1.15);
+  });
+});

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,83 +1,204 @@
-import type { OfficeEntity } from "../types/office";
+import type { OfficeEntity, OfficeEntityStatus } from "../types/office";
 
 export type RoomShape = "grid" | "ring" | "line" | "cluster";
+export type ZonePriorityKey = "status" | "role" | "parent" | "recent";
+export type EntityRole = "strategy" | "ops" | "build" | "spawn" | "recovery";
+
+type RoomRoutingSpec = {
+  statuses: OfficeEntityStatus[];
+  kinds: Array<OfficeEntity["kind"]>;
+  recentWeight: number;
+};
 
 export type RoomSpec = {
   id: string;
   label: string;
   shape: RoomShape;
+  role: EntityRole;
   x: number;
   y: number;
   width: number;
   height: number;
   fill: string;
   border: string;
+  capacity: number;
+  spacing: {
+    x: number;
+    y: number;
+  };
+  anchor: {
+    x: number;
+    y: number;
+  };
+  secondaryZoneId?: string;
+  routing: RoomRoutingSpec;
+};
+
+export type ZoneLayoutConfig = {
+  version: number;
+  priorityOrder: ZonePriorityKey[];
+  recentWindowMs: number;
+  parentAffinityPx: number;
+  defaultOverflowZoneId: string;
+  rooms: RoomSpec[];
 };
 
 export type Placement = {
   entity: OfficeEntity;
   roomId: string;
+  targetRoomId: string;
   x: number;
   y: number;
+  overflowed: boolean;
 };
 
-const ROOMS: RoomSpec[] = [
-  {
-    id: "strategy",
-    label: "Strategy Room",
-    shape: "ring",
-    x: 280,
-    y: 70,
-    width: 330,
-    height: 180,
-    fill: "rgba(47, 106, 140, 0.82)",
-    border: "#8cd7ff",
-  },
-  {
-    id: "ops",
-    label: "Ops Floor",
-    shape: "grid",
-    x: 70,
-    y: 210,
-    width: 420,
-    height: 250,
-    fill: "rgba(40, 88, 115, 0.85)",
-    border: "#74d1f8",
-  },
-  {
-    id: "build",
-    label: "Build Pods",
-    shape: "line",
-    x: 560,
-    y: 235,
-    width: 330,
-    height: 200,
-    fill: "rgba(44, 125, 132, 0.84)",
-    border: "#8cf8dc",
-  },
-  {
-    id: "spawn",
-    label: "Spawn Lab",
-    shape: "cluster",
-    x: 520,
-    y: 70,
-    width: 390,
-    height: 160,
-    fill: "rgba(17, 82, 111, 0.82)",
-    border: "#5ec6ff",
-  },
-  {
-    id: "lounge",
-    label: "Recovery Lounge",
-    shape: "cluster",
-    x: 300,
-    y: 470,
-    width: 420,
-    height: 150,
-    fill: "rgba(13, 97, 120, 0.82)",
-    border: "#70f2ff",
-  },
-];
+export type RoomDebugInfo = {
+  roomId: string;
+  capacity: number;
+  assigned: number;
+  targeted: number;
+  overflowIn: number;
+  overflowOut: number;
+  secondaryZoneId?: string;
+};
+
+export type PlacementResult = {
+  rooms: RoomSpec[];
+  placements: Placement[];
+  roomDebug: Map<string, RoomDebugInfo>;
+  configVersion: number;
+};
+
+const VALID_STATUSES: readonly OfficeEntityStatus[] = ["active", "idle", "offline", "ok", "error"];
+const VALID_PRIORITIES: readonly ZonePriorityKey[] = ["status", "role", "parent", "recent"];
+const DEFAULT_PRIORITY_ORDER: ZonePriorityKey[] = ["status", "role", "parent", "recent"];
+
+const DEFAULT_ZONE_CONFIG: ZoneLayoutConfig = {
+  version: 1,
+  priorityOrder: DEFAULT_PRIORITY_ORDER,
+  recentWindowMs: 5 * 60_000,
+  parentAffinityPx: 64,
+  defaultOverflowZoneId: "ops",
+  rooms: [
+    {
+      id: "strategy",
+      label: "Strategy Room",
+      shape: "ring",
+      role: "strategy",
+      x: 280,
+      y: 70,
+      width: 330,
+      height: 180,
+      fill: "rgba(47, 106, 140, 0.82)",
+      border: "#8cd7ff",
+      capacity: 10,
+      spacing: { x: 42, y: 28 },
+      anchor: { x: 0.5, y: 0.48 },
+      secondaryZoneId: "ops",
+      routing: {
+        statuses: ["active"],
+        kinds: ["agent"],
+        recentWeight: 0.2,
+      },
+    },
+    {
+      id: "ops",
+      label: "Ops Floor",
+      shape: "grid",
+      role: "ops",
+      x: 70,
+      y: 210,
+      width: 420,
+      height: 250,
+      fill: "rgba(40, 88, 115, 0.85)",
+      border: "#74d1f8",
+      capacity: 16,
+      spacing: { x: 64, y: 52 },
+      anchor: { x: 0.5, y: 0.5 },
+      secondaryZoneId: "build",
+      routing: {
+        statuses: ["ok", "offline"],
+        kinds: ["agent"],
+        recentWeight: 0.15,
+      },
+    },
+    {
+      id: "build",
+      label: "Build Pods",
+      shape: "line",
+      role: "build",
+      x: 560,
+      y: 235,
+      width: 330,
+      height: 200,
+      fill: "rgba(44, 125, 132, 0.84)",
+      border: "#8cf8dc",
+      capacity: 12,
+      spacing: { x: 56, y: 36 },
+      anchor: { x: 0.5, y: 0.52 },
+      secondaryZoneId: "ops",
+      routing: {
+        statuses: ["idle"],
+        kinds: ["agent"],
+        recentWeight: 0.1,
+      },
+    },
+    {
+      id: "spawn",
+      label: "Spawn Lab",
+      shape: "cluster",
+      role: "spawn",
+      x: 520,
+      y: 70,
+      width: 390,
+      height: 160,
+      fill: "rgba(17, 82, 111, 0.82)",
+      border: "#5ec6ff",
+      capacity: 14,
+      spacing: { x: 48, y: 30 },
+      anchor: { x: 0.54, y: 0.52 },
+      secondaryZoneId: "ops",
+      routing: {
+        statuses: ["active", "idle"],
+        kinds: ["subagent"],
+        recentWeight: 0.35,
+      },
+    },
+    {
+      id: "lounge",
+      label: "Recovery Lounge",
+      shape: "cluster",
+      role: "recovery",
+      x: 300,
+      y: 470,
+      width: 420,
+      height: 150,
+      fill: "rgba(13, 97, 120, 0.82)",
+      border: "#70f2ff",
+      capacity: 12,
+      spacing: { x: 54, y: 28 },
+      anchor: { x: 0.5, y: 0.52 },
+      secondaryZoneId: "ops",
+      routing: {
+        statuses: ["ok", "error", "offline"],
+        kinds: ["agent", "subagent"],
+        recentWeight: 0.25,
+      },
+    },
+  ],
+};
+
+type ScoreVector = Record<ZonePriorityKey, number>;
+
+type AssignmentMeta = {
+  roomId: string;
+  targetRoomId: string;
+  overflowed: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
 
 function hashString(input: string): number {
   let hash = 0;
@@ -87,57 +208,193 @@ function hashString(input: string): number {
   return hash;
 }
 
-function layoutPoint(params: {
-  shape: RoomShape;
-  index: number;
-  total: number;
-  room: RoomSpec;
-  seed: string;
-}): { x: number; y: number } {
-  const { shape, index, total, room, seed } = params;
-  const ratio = total <= 1 ? 0.5 : index / (total - 1);
+function toFiniteNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
 
-  if (shape === "ring") {
-    const angle = (Math.PI * 2 * index) / Math.max(total, 1) - Math.PI / 2;
-    const rx = room.width * 0.34;
-    const ry = room.height * 0.28;
-    return {
-      x: room.x + room.width / 2 + Math.cos(angle) * rx,
-      y: room.y + room.height / 2 + Math.sin(angle) * ry,
-    };
+function toString(value: unknown, fallback: string): string {
+  if (typeof value === "string" && value.trim() !== "") {
+    return value;
+  }
+  return fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function isRoomShape(value: unknown): value is RoomShape {
+  return value === "grid" || value === "ring" || value === "line" || value === "cluster";
+}
+
+function isEntityRole(value: unknown): value is EntityRole {
+  return (
+    value === "strategy" ||
+    value === "ops" ||
+    value === "build" ||
+    value === "spawn" ||
+    value === "recovery"
+  );
+}
+
+function normalizeStatuses(value: unknown, fallback: OfficeEntityStatus[]): OfficeEntityStatus[] {
+  if (!Array.isArray(value)) {
+    return fallback;
+  }
+  const normalized = value.filter(
+    (entry): entry is OfficeEntityStatus =>
+      typeof entry === "string" && (VALID_STATUSES as readonly string[]).includes(entry),
+  );
+  return normalized.length > 0 ? normalized : fallback;
+}
+
+function normalizeKinds(
+  value: unknown,
+  fallback: Array<OfficeEntity["kind"]>,
+): Array<OfficeEntity["kind"]> {
+  if (!Array.isArray(value)) {
+    return fallback;
+  }
+  const normalized = value.filter(
+    (entry): entry is OfficeEntity["kind"] => entry === "agent" || entry === "subagent",
+  );
+  return normalized.length > 0 ? normalized : fallback;
+}
+
+function normalizePriorityOrder(value: unknown): ZonePriorityKey[] {
+  if (!Array.isArray(value)) {
+    return DEFAULT_PRIORITY_ORDER;
+  }
+  const normalized = value.filter(
+    (entry): entry is ZonePriorityKey =>
+      typeof entry === "string" && (VALID_PRIORITIES as readonly string[]).includes(entry),
+  );
+  if (normalized.length === 0) {
+    return DEFAULT_PRIORITY_ORDER;
+  }
+  const deduped: ZonePriorityKey[] = [];
+  for (const key of normalized) {
+    if (!deduped.includes(key)) {
+      deduped.push(key);
+    }
+  }
+  for (const key of DEFAULT_PRIORITY_ORDER) {
+    if (!deduped.includes(key)) {
+      deduped.push(key);
+    }
+  }
+  return deduped;
+}
+
+function normalizeRoom(rawValue: unknown, fallback: RoomSpec): RoomSpec {
+  const raw = isRecord(rawValue) ? rawValue : {};
+  const rawSpacing = isRecord(raw.spacing) ? raw.spacing : {};
+  const rawAnchor = isRecord(raw.anchor) ? raw.anchor : {};
+  const rawRouting = isRecord(raw.routing) ? raw.routing : {};
+
+  const room: RoomSpec = {
+    ...fallback,
+    label: toString(raw.label, fallback.label),
+    shape: isRoomShape(raw.shape) ? raw.shape : fallback.shape,
+    role: isEntityRole(raw.role) ? raw.role : fallback.role,
+    x: toFiniteNumber(raw.x, fallback.x),
+    y: toFiniteNumber(raw.y, fallback.y),
+    width: Math.max(120, toFiniteNumber(raw.width, fallback.width)),
+    height: Math.max(80, toFiniteNumber(raw.height, fallback.height)),
+    fill: toString(raw.fill, fallback.fill),
+    border: toString(raw.border, fallback.border),
+    capacity: Math.max(1, Math.round(toFiniteNumber(raw.capacity, fallback.capacity))),
+    spacing: {
+      x: Math.max(18, toFiniteNumber(rawSpacing.x, fallback.spacing.x)),
+      y: Math.max(14, toFiniteNumber(rawSpacing.y, fallback.spacing.y)),
+    },
+    anchor: {
+      x: clamp(toFiniteNumber(rawAnchor.x, fallback.anchor.x), 0, 1),
+      y: clamp(toFiniteNumber(rawAnchor.y, fallback.anchor.y), 0, 1),
+    },
+    secondaryZoneId:
+      typeof raw.secondaryZoneId === "string" && raw.secondaryZoneId.length > 0
+        ? raw.secondaryZoneId
+        : fallback.secondaryZoneId,
+    routing: {
+      statuses: normalizeStatuses(rawRouting.statuses, fallback.routing.statuses),
+      kinds: normalizeKinds(rawRouting.kinds, fallback.routing.kinds),
+      recentWeight: toFiniteNumber(rawRouting.recentWeight, fallback.routing.recentWeight),
+    },
+  };
+  return room;
+}
+
+export function normalizeZoneConfig(rawValue: unknown): ZoneLayoutConfig {
+  const raw = isRecord(rawValue) ? rawValue : {};
+  const rawRoomsById = new Map<string, unknown>();
+  if (Array.isArray(raw.rooms)) {
+    for (const rawRoom of raw.rooms) {
+      if (isRecord(rawRoom) && typeof rawRoom.id === "string") {
+        rawRoomsById.set(rawRoom.id, rawRoom);
+      }
+    }
   }
 
-  if (shape === "grid") {
-    const cols = Math.max(2, Math.ceil(Math.sqrt(total)));
-    const col = index % cols;
-    const row = Math.floor(index / cols);
-    const rows = Math.max(1, Math.ceil(total / cols));
-    const x = room.x + 36 + (col / Math.max(cols - 1, 1)) * (room.width - 72);
-    const y = room.y + 30 + (row / Math.max(rows - 1, 1)) * (room.height - 62);
-    return { x, y };
+  const rooms = DEFAULT_ZONE_CONFIG.rooms.map((fallback) =>
+    normalizeRoom(rawRoomsById.get(fallback.id), fallback),
+  );
+  const roomIds = new Set(rooms.map((room) => room.id));
+  for (const room of rooms) {
+    if (room.secondaryZoneId && !roomIds.has(room.secondaryZoneId)) {
+      room.secondaryZoneId = undefined;
+    }
   }
 
-  if (shape === "line") {
-    return {
-      x: room.x + 28 + ratio * (room.width - 56),
-      y: room.y + room.height * 0.3 + (index % 2 === 0 ? -20 : 22),
-    };
-  }
+  const defaultOverflowCandidate = toString(
+    raw.defaultOverflowZoneId,
+    DEFAULT_ZONE_CONFIG.defaultOverflowZoneId,
+  );
+  const defaultOverflowZoneId = roomIds.has(defaultOverflowCandidate)
+    ? defaultOverflowCandidate
+    : DEFAULT_ZONE_CONFIG.defaultOverflowZoneId;
 
-  const hash = hashString(seed);
-  const jitterX = ((hash % 100) / 100 - 0.5) * room.width * 0.25;
-  const jitterY = (((hash / 100) % 100) / 100 - 0.5) * room.height * 0.3;
   return {
-    x: room.x + room.width * (0.18 + ratio * 0.64) + jitterX,
-    y: room.y + room.height * (0.35 + ((index % 3) - 1) * 0.18) + jitterY,
+    version: Math.max(1, Math.round(toFiniteNumber(raw.version, DEFAULT_ZONE_CONFIG.version))),
+    priorityOrder: normalizePriorityOrder(raw.priorityOrder),
+    recentWindowMs: Math.max(
+      0,
+      Math.round(toFiniteNumber(raw.recentWindowMs, DEFAULT_ZONE_CONFIG.recentWindowMs)),
+    ),
+    parentAffinityPx: Math.max(
+      0,
+      toFiniteNumber(raw.parentAffinityPx, DEFAULT_ZONE_CONFIG.parentAffinityPx),
+    ),
+    defaultOverflowZoneId: roomIds.has(defaultOverflowZoneId) ? defaultOverflowZoneId : rooms[0].id,
+    rooms,
   };
 }
 
-function classifyRoom(entity: OfficeEntity): string {
+function compareEntities(a: OfficeEntity, b: OfficeEntity): number {
+  const kindOrder = a.kind === b.kind ? 0 : a.kind === "agent" ? -1 : 1;
+  if (kindOrder !== 0) {
+    return kindOrder;
+  }
+  const labelOrder = a.label.localeCompare(b.label);
+  if (labelOrder !== 0) {
+    return labelOrder;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+function deriveRole(entity: OfficeEntity): EntityRole {
   if (entity.kind === "subagent") {
-    // Completed or errored subagents go to Recovery Lounge
-    if (entity.status === "ok" || entity.status === "error") {
-      return "lounge";
+    if (entity.status === "ok" || entity.status === "error" || entity.status === "offline") {
+      return "recovery";
     }
     return "spawn";
   }
@@ -148,49 +405,372 @@ function classifyRoom(entity: OfficeEntity): string {
     return "build";
   }
   if (entity.status === "error" || entity.status === "offline") {
-    return "lounge";
+    return "recovery";
   }
   return "ops";
 }
 
-export function getRooms(): RoomSpec[] {
-  return ROOMS;
+function scoreRoom(params: {
+  entity: OfficeEntity;
+  role: EntityRole;
+  room: RoomSpec;
+  parentRoomId?: string;
+  generatedAt: number;
+  recentWindowMs: number;
+}): ScoreVector {
+  const { entity, role, room, parentRoomId, generatedAt, recentWindowMs } = params;
+  const statusMatch = room.routing.statuses.includes(entity.status) ? 1 : 0;
+  const kindMatch = room.routing.kinds.includes(entity.kind) ? 1 : 0;
+  const roleMatch = room.role === role ? 1 : 0;
+  const parentMatch = entity.kind === "subagent" && parentRoomId === room.id ? 1 : 0;
+  const isRecent =
+    typeof entity.lastUpdatedAt === "number" &&
+    generatedAt - entity.lastUpdatedAt >= 0 &&
+    generatedAt - entity.lastUpdatedAt <= recentWindowMs;
+
+  return {
+    status: statusMatch,
+    role: kindMatch + roleMatch,
+    parent: parentMatch,
+    recent: isRecent ? room.routing.recentWeight : 0,
+  };
 }
 
-export function buildPlacements(entities: OfficeEntity[]): Placement[] {
-  const roomBuckets = new Map<string, OfficeEntity[]>();
-  for (const room of ROOMS) {
-    roomBuckets.set(room.id, []);
+function compareScoreVectors(
+  left: ScoreVector,
+  right: ScoreVector,
+  priorityOrder: ZonePriorityKey[],
+): number {
+  for (const key of priorityOrder) {
+    if (left[key] > right[key]) {
+      return 1;
+    }
+    if (left[key] < right[key]) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+function pickTargetRoom(params: {
+  entity: OfficeEntity;
+  rooms: RoomSpec[];
+  priorityOrder: ZonePriorityKey[];
+  generatedAt: number;
+  recentWindowMs: number;
+  parentRoomByAgentId: Map<string, string>;
+}): RoomSpec {
+  const { entity, rooms, priorityOrder, generatedAt, recentWindowMs, parentRoomByAgentId } = params;
+  const role = deriveRole(entity);
+  const parentRoomId = entity.parentAgentId
+    ? parentRoomByAgentId.get(entity.parentAgentId)
+    : undefined;
+
+  let bestRoom = rooms[0];
+  let bestScore = scoreRoom({
+    entity,
+    role,
+    room: bestRoom,
+    parentRoomId,
+    generatedAt,
+    recentWindowMs,
+  });
+
+  for (let index = 1; index < rooms.length; index += 1) {
+    const candidate = rooms[index];
+    const candidateScore = scoreRoom({
+      entity,
+      role,
+      room: candidate,
+      parentRoomId,
+      generatedAt,
+      recentWindowMs,
+    });
+    const comparison = compareScoreVectors(candidateScore, bestScore, priorityOrder);
+    if (comparison > 0 || (comparison === 0 && candidate.id.localeCompare(bestRoom.id) < 0)) {
+      bestRoom = candidate;
+      bestScore = candidateScore;
+    }
   }
 
-  for (const entity of entities) {
-    const roomId = classifyRoom(entity);
-    const bucket = roomBuckets.get(roomId);
-    if (bucket) {
-      bucket.push(entity);
+  return bestRoom;
+}
+
+function resolveOverflowRoom(params: {
+  targetRoom: RoomSpec;
+  rooms: RoomSpec[];
+  roomById: Map<string, RoomSpec>;
+  occupancyByRoom: Map<string, number>;
+  defaultOverflowZoneId: string;
+}): { roomId: string; overflowed: boolean } {
+  const { targetRoom, rooms, roomById, occupancyByRoom, defaultOverflowZoneId } = params;
+  const targetOccupancy = occupancyByRoom.get(targetRoom.id) ?? 0;
+  if (targetOccupancy < targetRoom.capacity) {
+    return { roomId: targetRoom.id, overflowed: false };
+  }
+
+  const visited = new Set<string>([targetRoom.id]);
+  let nextId = targetRoom.secondaryZoneId ?? defaultOverflowZoneId;
+  while (typeof nextId === "string" && nextId.length > 0 && !visited.has(nextId)) {
+    visited.add(nextId);
+    const room = roomById.get(nextId);
+    if (!room) {
+      break;
+    }
+    const occupancy = occupancyByRoom.get(room.id) ?? 0;
+    if (occupancy < room.capacity) {
+      return { roomId: room.id, overflowed: true };
+    }
+    nextId = room.secondaryZoneId ?? defaultOverflowZoneId;
+  }
+
+  let fallbackRoom = targetRoom;
+  let bestSpare = targetRoom.capacity - targetOccupancy;
+  for (const room of rooms) {
+    const spare = room.capacity - (occupancyByRoom.get(room.id) ?? 0);
+    if (spare > bestSpare || (spare === bestSpare && room.id.localeCompare(fallbackRoom.id) < 0)) {
+      fallbackRoom = room;
+      bestSpare = spare;
+    }
+  }
+
+  return { roomId: fallbackRoom.id, overflowed: fallbackRoom.id !== targetRoom.id };
+}
+
+function clampPointToRoom(point: { x: number; y: number }, room: RoomSpec): { x: number; y: number } {
+  const marginX = Math.max(16, room.spacing.x * 0.3);
+  const marginY = Math.max(16, room.spacing.y * 0.3);
+  return {
+    x: clamp(point.x, room.x + marginX, room.x + room.width - marginX),
+    y: clamp(point.y, room.y + marginY, room.y + room.height - marginY),
+  };
+}
+
+function layoutPoint(params: {
+  room: RoomSpec;
+  index: number;
+  total: number;
+  seed: string;
+}): { x: number; y: number } {
+  const { room, index, total, seed } = params;
+  const ratio = total <= 1 ? 0.5 : index / (total - 1);
+  const anchorX = room.x + room.width * room.anchor.x;
+  const anchorY = room.y + room.height * room.anchor.y;
+
+  if (room.shape === "ring") {
+    const angle = (Math.PI * 2 * index) / Math.max(total, 1) - Math.PI / 2;
+    const rx = Math.max(room.spacing.x * 1.25, room.width * 0.22);
+    const ry = Math.max(room.spacing.y * 1.1, room.height * 0.2);
+    return clampPointToRoom(
+      {
+        x: anchorX + Math.cos(angle) * rx,
+        y: anchorY + Math.sin(angle) * ry,
+      },
+      room,
+    );
+  }
+
+  if (room.shape === "grid") {
+    const cols = Math.max(1, Math.floor((room.width - room.spacing.x) / room.spacing.x));
+    const rows = Math.max(1, Math.ceil(total / cols));
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+    const startX = anchorX - ((cols - 1) * room.spacing.x) / 2;
+    const startY = anchorY - ((rows - 1) * room.spacing.y) / 2;
+    return clampPointToRoom(
+      {
+        x: startX + col * room.spacing.x,
+        y: startY + row * room.spacing.y,
+      },
+      room,
+    );
+  }
+
+  if (room.shape === "line") {
+    const insetX = Math.max(20, room.spacing.x * 0.45);
+    return clampPointToRoom(
+      {
+        x: room.x + insetX + ratio * (room.width - insetX * 2),
+        y: anchorY + (index % 2 === 0 ? -1 : 1) * room.spacing.y * 0.45,
+      },
+      room,
+    );
+  }
+
+  const hash = hashString(seed);
+  const jitterX = ((hash % 101) / 100 - 0.5) * room.spacing.x * 2.1;
+  const jitterY = (((Math.floor(hash / 101) % 101) / 100) - 0.5) * room.spacing.y * 1.8;
+  const driftX = (ratio - 0.5) * room.spacing.x * 1.4;
+  const driftY = ((index % 3) - 1) * room.spacing.y * 0.45;
+  return clampPointToRoom(
+    {
+      x: anchorX + jitterX + driftX,
+      y: anchorY + jitterY + driftY,
+    },
+    room,
+  );
+}
+
+function applyParentAffinity(params: {
+  point: { x: number; y: number };
+  room: RoomSpec;
+  parentPoint: { x: number; y: number };
+  seed: string;
+  parentAffinityPx: number;
+}): { x: number; y: number } {
+  const { point, room, parentPoint, seed, parentAffinityPx } = params;
+  if (parentAffinityPx <= 0) {
+    return point;
+  }
+  const hash = hashString(seed);
+  const angle = ((hash % 360) * Math.PI) / 180;
+  const radius = 10 + (hash % Math.max(12, Math.round(parentAffinityPx * 0.75)));
+  const distance = Math.min(parentAffinityPx, radius);
+  return clampPointToRoom(
+    {
+      x: parentPoint.x + Math.cos(angle) * distance,
+      y: parentPoint.y + Math.sin(angle) * distance * 0.72,
+    },
+    room,
+  );
+}
+
+export function getRooms(zoneConfig?: unknown): RoomSpec[] {
+  return normalizeZoneConfig(zoneConfig).rooms;
+}
+
+export function buildPlacements(params: {
+  entities: OfficeEntity[];
+  generatedAt: number;
+  zoneConfig?: unknown;
+}): PlacementResult {
+  const config = normalizeZoneConfig(params.zoneConfig);
+  const rooms = config.rooms;
+  const roomById = new Map(rooms.map((room) => [room.id, room]));
+
+  const roomBuckets = new Map<string, OfficeEntity[]>();
+  const occupancyByRoom = new Map<string, number>();
+  const targetedByRoom = new Map<string, number>();
+  const overflowOutByRoom = new Map<string, number>();
+  const overflowInByRoom = new Map<string, number>();
+  const parentRoomByAgentId = new Map<string, string>();
+  const assignmentByEntityId = new Map<string, AssignmentMeta>();
+
+  for (const room of rooms) {
+    roomBuckets.set(room.id, []);
+    occupancyByRoom.set(room.id, 0);
+  }
+
+  const assignmentOrder = [...params.entities].sort(compareEntities);
+
+  for (const entity of assignmentOrder) {
+    const targetRoom = pickTargetRoom({
+      entity,
+      rooms,
+      priorityOrder: config.priorityOrder,
+      generatedAt: params.generatedAt,
+      recentWindowMs: config.recentWindowMs,
+      parentRoomByAgentId,
+    });
+
+    targetedByRoom.set(targetRoom.id, (targetedByRoom.get(targetRoom.id) ?? 0) + 1);
+
+    const resolved = resolveOverflowRoom({
+      targetRoom,
+      rooms,
+      roomById,
+      occupancyByRoom,
+      defaultOverflowZoneId: config.defaultOverflowZoneId,
+    });
+    occupancyByRoom.set(resolved.roomId, (occupancyByRoom.get(resolved.roomId) ?? 0) + 1);
+
+    if (resolved.overflowed) {
+      overflowOutByRoom.set(targetRoom.id, (overflowOutByRoom.get(targetRoom.id) ?? 0) + 1);
+      overflowInByRoom.set(resolved.roomId, (overflowInByRoom.get(resolved.roomId) ?? 0) + 1);
+    }
+
+    roomBuckets.get(resolved.roomId)?.push(entity);
+    assignmentByEntityId.set(entity.id, {
+      roomId: resolved.roomId,
+      targetRoomId: targetRoom.id,
+      overflowed: resolved.overflowed,
+    });
+
+    if (entity.kind === "agent") {
+      parentRoomByAgentId.set(entity.agentId, resolved.roomId);
     }
   }
 
   const placements: Placement[] = [];
-  for (const room of ROOMS) {
+  const agentPointByAgentId = new Map<string, { x: number; y: number; roomId: string }>();
+
+  for (const room of rooms) {
     const bucket = roomBuckets.get(room.id) ?? [];
-    bucket.sort((a, b) => a.label.localeCompare(b.label));
+    bucket.sort(compareEntities);
     bucket.forEach((entity, index) => {
-      const point = layoutPoint({
-        shape: room.shape,
+      let point = layoutPoint({
+        room,
         index,
         total: bucket.length,
-        room,
         seed: entity.id,
       });
+
+      if (entity.kind === "subagent" && entity.parentAgentId) {
+        const parentPoint = agentPointByAgentId.get(entity.parentAgentId);
+        if (parentPoint && parentPoint.roomId === room.id) {
+          point = applyParentAffinity({
+            point,
+            room,
+            parentPoint,
+            seed: entity.id,
+            parentAffinityPx: config.parentAffinityPx,
+          });
+        }
+      }
+
+      const assignment = assignmentByEntityId.get(entity.id);
+      if (!assignment) {
+        return;
+      }
+
       placements.push({
         entity,
         roomId: room.id,
+        targetRoomId: assignment.targetRoomId,
         x: point.x,
         y: point.y,
+        overflowed: assignment.overflowed,
       });
+
+      if (entity.kind === "agent") {
+        agentPointByAgentId.set(entity.agentId, {
+          x: point.x,
+          y: point.y,
+          roomId: room.id,
+        });
+      }
     });
   }
 
-  return placements;
+  const roomDebug = new Map<string, RoomDebugInfo>();
+  for (const room of rooms) {
+    const assigned = roomBuckets.get(room.id)?.length ?? 0;
+    const targeted = targetedByRoom.get(room.id) ?? 0;
+    roomDebug.set(room.id, {
+      roomId: room.id,
+      capacity: room.capacity,
+      assigned,
+      targeted,
+      overflowIn: overflowInByRoom.get(room.id) ?? 0,
+      overflowOut: overflowOutByRoom.get(room.id) ?? 0,
+      secondaryZoneId: room.secondaryZoneId,
+    });
+  }
+
+  return {
+    rooms,
+    placements,
+    roomDebug,
+    configVersion: config.version,
+  };
 }


### PR DESCRIPTION
## Summary
- introduce a JSON-based Zone rule engine (`public/assets/layout/zone-config.json`) for deterministic room routing
- upgrade placement logic to v2 with priority scoring (`status > role > parent > recent`), capacity overflow routing, and parent-subagent proximity controls
- add room-level layout debug overlay (`cap/target/overflow`) in stage rendering
- add unit tests for deterministic output, overflow no-loss behavior, and parent affinity behavior

## Key Changes
- `src/lib/layout.ts`
  - replace static shape classifier with normalized `ZoneLayoutConfig` pipeline
  - add room scoring, overflow chain resolution, and deterministic placement order
  - add parent affinity placement and room debug metadata
- `src/components/OfficeStage.tsx`
  - load `/assets/layout/zone-config.json` at runtime (periodic reload for policy recalculation)
  - use new placement result (rooms + placements + roomDebug)
  - render zone debug overlay per room
- `src/App.css`
  - add zone debug badge styles
- `README.md`
  - document zone rule engine, debug overlay, and layout policy reload behavior
- `src/lib/layout.test.ts`
  - add placement engine unit tests
- `public/assets/layout/zone-config.json`
  - add default Zone DSL policy

## Validation
- `pnpm ci:local`
  - lint: pass
  - tests: pass (16/16)
  - build: pass

Closes #4
