### PR TITLE
[Issue #7] timeline filters playback and deep-link sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Web-based visual command center for OpenClaw agents and subagents.
 - Room-level debug overlay (`cap/target/overflow`) for layout diagnostics
 - Lifecycle motion tokens for spawn/start/end/error/cleanup + reduced-motion fallback
 - Entity detail panel (`Overview / Sessions / Runs / Messages / Metrics`) with copy actions
+- Timeline debugger with `runId/agentId/status` filters + playback + run deep link
 
 ## Motion Lifecycle Guide
 
@@ -65,6 +66,14 @@ Web-based visual command center for OpenClaw agents and subagents.
 3. 장애 상태 엔티티 선택 후 Messages에서 `error/end/cleanup` 순서를 시간축으로 추적
 4. Session key/run ID를 복사해 터미널/로그 검색으로 즉시 전환
 5. Metrics에서 run/error/event 밀도를 확인해 타임라인 대비 병목 후보를 빠르게 좁힘
+
+## Timeline Deep Link
+
+타임라인 패널은 필터/재생과 스테이지 하이라이트를 동기화합니다.
+
+- `runId` 필터 딥링크: `?runId=<run-id>`
+- 타임라인 재생 중 현재 이벤트는 스테이지 엔티티/링크 하이라이트와 동기화
+- 타임라인 인덱싱/필터/재생 시나리오는 `src/lib/timeline.test.ts`로 검증
 
 ## Data source
 

--- a/src/App.css
+++ b/src/App.css
@@ -322,6 +322,17 @@ body {
   animation: pulse-line 2.2s linear infinite;
 }
 
+.run-link.run-highlight {
+  stroke-width: 3.1;
+  opacity: 1;
+  filter: drop-shadow(0 0 9px rgba(255, 229, 166, 0.72));
+}
+
+.run-link.run-muted {
+  opacity: 0.18;
+  filter: none;
+}
+
 .run-link.run-ok {
   stroke: #85ffc4;
   opacity: 0.54;
@@ -529,6 +540,19 @@ body {
   color: #fff7d2;
 }
 
+.entity-token.is-linked .sprite-shell {
+  box-shadow: 0 0 0 2px rgba(166, 230, 255, 0.78), 0 0 18px rgba(125, 212, 255, 0.5);
+}
+
+.entity-token.is-linked .token-meta strong {
+  color: #dff6ff;
+}
+
+.entity-token.is-muted {
+  opacity: 0.34;
+  filter: saturate(0.65);
+}
+
 .entity-token.is-overflowed {
   filter: saturate(0.84) brightness(0.92);
 }
@@ -686,6 +710,7 @@ body {
   background: rgba(7, 26, 38, 0.88);
   display: flex;
   flex-direction: column;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -708,6 +733,101 @@ body {
   line-height: 1.4;
 }
 
+.timeline-filters {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(146, 226, 255, 0.2);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  gap: 6px;
+}
+
+.timeline-filters label {
+  display: grid;
+  gap: 4px;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #91c9dc;
+}
+
+.timeline-filters input,
+.timeline-filters select,
+.timeline-speed select {
+  border-radius: 8px;
+  border: 1px solid rgba(144, 221, 255, 0.34);
+  background: rgba(6, 32, 46, 0.92);
+  color: #dcf6ff;
+  font-size: 0.7rem;
+  padding: 5px 7px;
+}
+
+.timeline-clear {
+  align-self: end;
+  border-radius: 8px;
+  border: 1px solid rgba(144, 221, 255, 0.4);
+  background: rgba(10, 45, 65, 0.9);
+  color: #d2f2ff;
+  font-size: 0.68rem;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.timeline-controls {
+  padding: 8px 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid rgba(146, 226, 255, 0.16);
+}
+
+.timeline-buttons {
+  display: flex;
+  gap: 6px;
+}
+
+.timeline-buttons button {
+  border-radius: 8px;
+  border: 1px solid rgba(152, 229, 255, 0.38);
+  background: rgba(9, 39, 55, 0.9);
+  color: #d9f5ff;
+  font-size: 0.68rem;
+  padding: 5px 8px;
+  cursor: pointer;
+}
+
+.timeline-buttons button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.timeline-speed {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.66rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #93cadc;
+}
+
+.timeline-scrubber {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(146, 226, 255, 0.12);
+}
+
+.timeline-scrubber input {
+  width: 100%;
+}
+
+.timeline-scrubber-meta {
+  margin-top: 4px;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.64rem;
+  color: #8ec5d8;
+}
+
 .event-rail ol {
   margin: 0;
   padding: 8px;
@@ -719,12 +839,28 @@ body {
 
 .event {
   display: grid;
-  grid-template-columns: 58px 1fr;
-  gap: 8px;
   border: 1px solid rgba(137, 223, 255, 0.18);
   border-radius: 10px;
   background: rgba(7, 23, 35, 0.8);
+  padding: 0;
+}
+
+.event.is-current {
+  border-color: rgba(255, 215, 144, 0.62);
+  box-shadow: 0 0 0 1px rgba(255, 215, 144, 0.45);
+}
+
+.event-hit {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  width: 100%;
+  text-align: left;
+  display: grid;
+  grid-template-columns: 58px 1fr;
+  gap: 8px;
   padding: 8px;
+  cursor: pointer;
 }
 
 .event .badge {
@@ -751,6 +887,12 @@ body {
 .event-body time {
   font-size: 0.64rem;
   color: #8fc8dc;
+}
+
+.event-meta {
+  margin: 5px 0 0;
+  font-size: 0.64rem;
+  color: #8dc2d6;
 }
 
 .event-spawn .badge {
@@ -1167,6 +1309,14 @@ body {
   .detail-panel {
     min-height: 320px;
   }
+
+  .timeline-filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .timeline-clear {
+    grid-column: span 2;
+  }
 }
 
 @media (max-width: 760px) {
@@ -1209,6 +1359,19 @@ body {
 
   .detail-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .timeline-filters {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .timeline-clear {
+    grid-column: span 1;
+  }
+
+  .timeline-controls {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .footer-bar {

--- a/src/components/EventRail.tsx
+++ b/src/components/EventRail.tsx
@@ -1,11 +1,24 @@
+import { useEffect, useMemo, useState } from "react";
 import type { OfficeEvent } from "../types/office";
+import {
+  buildTimelineIndex,
+  filterTimelineEvents,
+  nextPlaybackEventId,
+  type TimelineFilters,
+  type TimelineStatusFilter,
+} from "../lib/timeline";
 
 type Props = {
   events: OfficeEvent[];
+  now: number;
+  filters: TimelineFilters;
+  onFiltersChange: (next: TimelineFilters) => void;
+  activeEventId: string | null;
+  onActiveEventIdChange: (eventId: string | null) => void;
 };
 
-function relativeTime(timestamp: number) {
-  const ms = Date.now() - timestamp;
+function relativeTime(timestamp: number, now: number) {
+  const ms = Math.max(0, now - timestamp);
   if (ms < 60_000) {
     return `${Math.max(1, Math.floor(ms / 1000))}s ago`;
   }
@@ -31,26 +44,216 @@ function eventBadge(type: OfficeEvent["type"]) {
   return "DONE";
 }
 
-export function EventRail({ events }: Props) {
-  const top = events.slice(0, 24);
+export function EventRail({
+  events,
+  now,
+  filters,
+  onFiltersChange,
+  activeEventId,
+  onActiveEventIdChange,
+}: Props) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackMs, setPlaybackMs] = useState(800);
+
+  const index = useMemo(() => buildTimelineIndex(events), [events]);
+  const filteredDesc = useMemo(() => filterTimelineEvents(index, filters), [index, filters]);
+  const playbackEvents = useMemo(
+    () => [...filteredDesc].sort((a, b) => a.at - b.at),
+    [filteredDesc],
+  );
+  const activePlaybackIndex = playbackEvents.findIndex((event) => event.id === activeEventId);
+
+  useEffect(() => {
+    if (playbackEvents.length === 0) {
+      if (activeEventId !== null) {
+        onActiveEventIdChange(null);
+      }
+      return;
+    }
+    const hasCurrent = activeEventId
+      ? playbackEvents.some((event) => event.id === activeEventId)
+      : false;
+    if (!hasCurrent) {
+      onActiveEventIdChange(playbackEvents[0]?.id ?? null);
+    }
+  }, [activeEventId, onActiveEventIdChange, playbackEvents]);
+
+  useEffect(() => {
+    if (!isPlaying || playbackEvents.length === 0) {
+      return undefined;
+    }
+    const timer = window.setInterval(() => {
+      const nextId = nextPlaybackEventId(playbackEvents, activeEventId, 1);
+      if (!nextId) {
+        setIsPlaying(false);
+        return;
+      }
+      onActiveEventIdChange(nextId);
+    }, playbackMs);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [activeEventId, isPlaying, onActiveEventIdChange, playbackEvents, playbackMs]);
+
+  const activeEvent = activeEventId
+    ? playbackEvents.find((event) => event.id === activeEventId) ?? null
+    : null;
 
   return (
     <aside className="event-rail">
       <header>
-        <h2>Spawn Timeline</h2>
-        <p>Every subagent spawn, lifecycle step, and cleanup trace.</p>
+        <h2>Lifecycle Timeline</h2>
+        <p>Filter by run/agent/status and replay events with deep-linkable run context.</p>
       </header>
+
+      <section className="timeline-filters">
+        <label>
+          Run
+          <input
+            type="text"
+            placeholder="runId"
+            value={filters.runId}
+            onChange={(event) => {
+              onFiltersChange({ ...filters, runId: event.target.value });
+            }}
+          />
+        </label>
+        <label>
+          Agent
+          <input
+            type="text"
+            placeholder="agentId"
+            value={filters.agentId}
+            onChange={(event) => {
+              onFiltersChange({ ...filters, agentId: event.target.value });
+            }}
+          />
+        </label>
+        <label>
+          Status
+          <select
+            value={filters.status}
+            onChange={(event) => {
+              onFiltersChange({
+                ...filters,
+                status: event.target.value as TimelineStatusFilter,
+              });
+            }}
+          >
+            <option value="all">ALL</option>
+            <option value="spawn">SPAWN</option>
+            <option value="start">START</option>
+            <option value="end">END</option>
+            <option value="error">ERROR</option>
+            <option value="cleanup">CLEANUP</option>
+          </select>
+        </label>
+        <button
+          type="button"
+          className="timeline-clear"
+          onClick={() => {
+            onFiltersChange({ runId: "", agentId: "", status: "all" });
+            onActiveEventIdChange(null);
+            setIsPlaying(false);
+          }}
+        >
+          Clear
+        </button>
+      </section>
+
+      <section className="timeline-controls">
+        <div className="timeline-buttons">
+          <button
+            type="button"
+            onClick={() => {
+              const prevId = nextPlaybackEventId(playbackEvents, activeEventId, -1);
+              if (prevId) {
+                onActiveEventIdChange(prevId);
+              }
+            }}
+            disabled={playbackEvents.length === 0 || activePlaybackIndex <= 0}
+          >
+            Prev
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setIsPlaying((value) => !value);
+            }}
+            disabled={playbackEvents.length === 0}
+          >
+            {isPlaying ? "Pause" : "Play"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const nextId = nextPlaybackEventId(playbackEvents, activeEventId, 1);
+              if (nextId) {
+                onActiveEventIdChange(nextId);
+              }
+            }}
+            disabled={playbackEvents.length === 0 || activePlaybackIndex >= playbackEvents.length - 1}
+          >
+            Next
+          </button>
+        </div>
+        <label className="timeline-speed">
+          Speed
+          <select
+            value={playbackMs}
+            onChange={(event) => {
+              setPlaybackMs(Number(event.target.value));
+            }}
+          >
+            <option value={1200}>0.8x</option>
+            <option value={800}>1x</option>
+            <option value={450}>2x</option>
+          </select>
+        </label>
+      </section>
+
+      <section className="timeline-scrubber">
+        <input
+          type="range"
+          min={0}
+          max={Math.max(0, playbackEvents.length - 1)}
+          value={Math.max(0, activePlaybackIndex)}
+          onChange={(event) => {
+            const indexValue = Number(event.target.value);
+            onActiveEventIdChange(playbackEvents[indexValue]?.id ?? null);
+          }}
+          disabled={playbackEvents.length === 0}
+        />
+        <div className="timeline-scrubber-meta">
+          <span>{playbackEvents.length} events</span>
+          <span>{activeEvent ? new Date(activeEvent.at).toLocaleTimeString() : "-"}</span>
+        </div>
+      </section>
+
       <ol>
-        {top.map((event) => (
-          <li key={event.id} className={`event event-${event.type}`}>
-            <span className="badge">{eventBadge(event.type)}</span>
-            <div className="event-body">
-              <strong>
-                {event.parentAgentId} {"->"} {event.agentId}
-              </strong>
-              <p>{event.text}</p>
-              <time>{relativeTime(event.at)}</time>
-            </div>
+        {playbackEvents.map((event) => (
+          <li
+            key={event.id}
+            className={`event event-${event.type} ${activeEventId === event.id ? "is-current" : ""}`}
+          >
+            <button
+              type="button"
+              className="event-hit"
+              onClick={() => {
+                onActiveEventIdChange(event.id);
+              }}
+            >
+              <span className="badge">{eventBadge(event.type)}</span>
+              <div className="event-body">
+                <strong>
+                  {event.parentAgentId} {"->"} {event.agentId}
+                </strong>
+                <p>{event.text}</p>
+                <p className="event-meta">
+                  run {event.runId} | {relativeTime(event.at, now)}
+                </p>
+              </div>
+            </button>
           </li>
         ))}
       </ol>

--- a/src/lib/timeline.ts
+++ b/src/lib/timeline.ts
@@ -1,0 +1,129 @@
+import type { OfficeEvent } from "../types/office";
+
+export type TimelineStatusFilter = "all" | OfficeEvent["type"];
+
+export type TimelineFilters = {
+  runId: string;
+  agentId: string;
+  status: TimelineStatusFilter;
+};
+
+export type TimelineIndex = {
+  ordered: OfficeEvent[];
+  byRunId: Map<string, OfficeEvent[]>;
+  byAgentId: Map<string, OfficeEvent[]>;
+  byStatus: Map<OfficeEvent["type"], OfficeEvent[]>;
+};
+
+function normalizeFilterText(value: string): string {
+  return value.trim();
+}
+
+export function normalizeTimelineFilters(input: Partial<TimelineFilters>): TimelineFilters {
+  return {
+    runId: normalizeFilterText(input.runId ?? ""),
+    agentId: normalizeFilterText(input.agentId ?? ""),
+    status: input.status ?? "all",
+  };
+}
+
+function pushToMap(map: Map<string, OfficeEvent[]>, key: string, event: OfficeEvent) {
+  const existing = map.get(key);
+  if (existing) {
+    existing.push(event);
+    return;
+  }
+  map.set(key, [event]);
+}
+
+export function buildTimelineIndex(events: OfficeEvent[]): TimelineIndex {
+  const ordered = [...events].sort((a, b) => {
+    if (a.at !== b.at) {
+      return b.at - a.at;
+    }
+    return a.id.localeCompare(b.id);
+  });
+
+  const byRunId = new Map<string, OfficeEvent[]>();
+  const byAgentId = new Map<string, OfficeEvent[]>();
+  const byStatus = new Map<OfficeEvent["type"], OfficeEvent[]>();
+
+  for (const event of ordered) {
+    pushToMap(byRunId, event.runId, event);
+    pushToMap(byAgentId, event.agentId, event);
+    if (event.parentAgentId !== event.agentId) {
+      pushToMap(byAgentId, event.parentAgentId, event);
+    }
+
+    const statusEvents = byStatus.get(event.type);
+    if (statusEvents) {
+      statusEvents.push(event);
+    } else {
+      byStatus.set(event.type, [event]);
+    }
+  }
+
+  return { ordered, byRunId, byAgentId, byStatus };
+}
+
+export function filterTimelineEvents(index: TimelineIndex, rawFilters: TimelineFilters): OfficeEvent[] {
+  const filters = normalizeTimelineFilters(rawFilters);
+  const hasRunId = filters.runId.length > 0;
+  const hasAgentId = filters.agentId.length > 0;
+  const statusFilter = filters.status === "all" ? null : filters.status;
+
+  let candidates = index.ordered;
+  if (hasRunId) {
+    candidates = index.byRunId.get(filters.runId) ?? [];
+  } else if (hasAgentId) {
+    candidates = index.byAgentId.get(filters.agentId) ?? [];
+  } else if (statusFilter) {
+    candidates = index.byStatus.get(statusFilter) ?? [];
+  }
+
+  return candidates.filter((event) => {
+    if (hasRunId && event.runId !== filters.runId) {
+      return false;
+    }
+    if (
+      hasAgentId &&
+      event.agentId !== filters.agentId &&
+      event.parentAgentId !== filters.agentId
+    ) {
+      return false;
+    }
+    if (statusFilter && event.type !== statusFilter) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function parseRunIdDeepLink(search: string): string {
+  const params = new URLSearchParams(search);
+  return normalizeFilterText(params.get("runId") ?? "");
+}
+
+export function nextPlaybackEventId(
+  orderedEvents: OfficeEvent[],
+  currentEventId: string | null,
+  direction: 1 | -1 = 1,
+): string | null {
+  if (orderedEvents.length === 0) {
+    return null;
+  }
+  if (!currentEventId) {
+    return orderedEvents[0]?.id ?? null;
+  }
+
+  const currentIndex = orderedEvents.findIndex((event) => event.id === currentEventId);
+  if (currentIndex < 0) {
+    return orderedEvents[0]?.id ?? null;
+  }
+
+  const nextIndex = currentIndex + direction;
+  if (nextIndex < 0 || nextIndex >= orderedEvents.length) {
+    return null;
+  }
+  return orderedEvents[nextIndex]?.id ?? null;
+}


### PR DESCRIPTION
## Summary
- introduce timeline indexing layer (`src/lib/timeline.ts`) with run/agent/status indexes
- add timeline query helpers for deep link parsing and playback stepping
- rebuild `EventRail` as a debugger panel with:
  - runId / agentId / status filters
  - playback controls (prev / play-pause / next / speed)
  - scrubber jump slider
  - clickable events that set the active timeline point
- sync timeline focus with stage by highlighting related run links/entities in `OfficeStage`
- support URL deep link `?runId=...` via app-level state sync
- document deep-link/playback behavior in README and add timeline scenario tests

## Validation
- `pnpm ci:local`
  - lint: pass
  - tests: 24 passed
  - build: pass

## Notes
- playback order is chronological (oldest -> newest) for easier lifecycle reconstruction.

Closes #7
