### PR TITLE
[Refactor] OfficeStage 타입 명확화 (타일 엔트리/레이어 표현)

### DIFF
--- a/docs/room-blueprint.md
+++ b/docs/room-blueprint.md
@@ -6,6 +6,7 @@
 
 - Keep room tile/wall/furniture layout declarative.
 - Compile blueprint data into render layers without changing component code.
+- Keep tile layers explicit (`floor -> wall -> object`), while `entity -> overlay` stays in separate render passes.
 - Validate bad blueprint input with explicit diagnostics.
 
 ## Schema (v1)

--- a/src/lib/room-blueprint.ts
+++ b/src/lib/room-blueprint.ts
@@ -1,6 +1,7 @@
 import type { RoomSpec } from "./layout";
 
-export type StageLayer = "floor" | "wall" | "object";
+// Tile render layers only. Entity tokens and link overlays are rendered in separate passes.
+export type TileStageLayer = "floor" | "wall" | "object";
 
 export type TileSprite = {
   atlas: string;
@@ -13,7 +14,7 @@ export type TileSprite = {
 export type BlueprintLayerTile<TSprite extends TileSprite> = {
   id: string;
   roomId: string;
-  layer: StageLayer;
+  layer: TileStageLayer;
   x: number;
   y: number;
   z: number;
@@ -648,7 +649,7 @@ export function compileRoomBlueprintLayers<TSprite extends TileSprite>(params: {
       let x = 0;
       let y = 0;
       let z = 0;
-      let layer: StageLayer = "object";
+      let layer: TileStageLayer = "object";
       let sprite: TSprite | undefined;
 
       if (anchor.kind === "tile" || anchor.kind === "furniture") {


### PR DESCRIPTION
## Summary
- rename single tile entry type in `OfficeStage` from `TileCatalog` to `ResolvedTile`
- replace ambiguous `StageLayer` with `TileStageLayer` in room blueprint compiler types
- document the render model split (`floor -> wall -> object` tiles, `entity -> overlay` separate passes)

## Validation
- pnpm ci:local

Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 타일 렌더링 시스템의 타입 구조를 개선하여 코드 안정성을 강화했습니다.
  * 타일 레이어 구성을 명시적으로 정의하여 렌더링 로직을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->