### PR TITLE
[Capacity] 50-agent Baseline 정의 및 공통 측정 규격 수립

### DIFF
--- a/.github/ISSUE_TEMPLATE/capacity-aligned-feature.yml
+++ b/.github/ISSUE_TEMPLATE/capacity-aligned-feature.yml
@@ -1,0 +1,55 @@
+name: Capacity-aligned feature
+description: Use this template for features that must align with the local 50-agent baseline.
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Baseline reference: `docs/capacity-baseline.md`
+  - type: dropdown
+    id: target_profile
+    attributes:
+      label: Target capacity profile
+      options:
+        - local10
+        - local25
+        - local50
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Goal
+      description: Describe what user/ops problem this issue solves.
+    validations:
+      required: true
+  - type: textarea
+    id: baseline_impact
+    attributes:
+      label: Baseline metrics impact
+      description: Which metrics in docs/capacity-baseline.md may change?
+      placeholder: "layout p95, stream merge p95, heapUsed MB ..."
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: Include commands and expected pass criteria.
+      value: |
+        - [ ] pnpm benchmark:local50
+        - [ ] pnpm ci:local
+        - [ ] Manual probe (FPS / update latency) if UI behavior changes
+    validations:
+      required: true
+  - type: checkboxes
+    id: done
+    attributes:
+      label: Definition of Done
+      options:
+        - label: This issue explicitly references docs/capacity-baseline.md
+          required: true
+        - label: Capacity metrics are collected and attached in the PR
+          required: true

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ pnpm benchmark:local50
 - Benchmark scenario: `50 agents / 500 runs / 5000 events`
 - Pipeline budget constants: `src/lib/perf-budgets.ts`
 - Profiling report template: `docs/perf-local50.md`
+- Capacity baseline profiles (10/25/50): `docs/capacity-baseline.md`
 
 ## API endpoints (dev server)
 
@@ -192,3 +193,5 @@ A curation manifest is included at:
 - `127.0.0.1` 로컬 바인딩 전제 유지
 - 50-agent 운영 한계를 기준으로 목표/완료조건 정의
 - 보안 이슈는 로컬 단독 사용 전제에서 우선순위 제외
+- capacity 관련 이슈는 `docs/capacity-baseline.md`를 명시적으로 참조
+- 신규 feature 이슈는 `.github/ISSUE_TEMPLATE/capacity-aligned-feature.yml` 템플릿 우선 사용

--- a/docs/capacity-baseline.md
+++ b/docs/capacity-baseline.md
@@ -1,0 +1,58 @@
+# Capacity Baseline (10/25/50)
+
+## Scope
+- Operating mode: local-only (`127.0.0.1`)
+- Capacity target: up to 50 active agents
+- Security hardening/perimeter controls: out of scope in this baseline
+
+## Standard Fixture Set
+All capacity measurements must use the shared synthetic scenario generator:
+- source: `src/lib/local50-scenario.ts`
+- profile constants: `src/lib/perf-budgets.ts` (`CAPACITY_BASELINE_PROFILES`)
+
+| Profile | Agents | Runs | Events |
+| --- | --- | --- | --- |
+| `local10` | 10 | 100 | 1,000 |
+| `local25` | 25 | 250 | 2,500 |
+| `local50` | 50 | 500 | 5,000 |
+
+## Budget Categories
+Pipeline budgets are automatically collected in benchmark tests.
+
+| Category | Budget | Collection |
+| --- | --- | --- |
+| Session parser p95 | `<= 18ms` | auto (`benchmark:local50`) |
+| Run parser p95 | `<= 45ms` | auto (`benchmark:local50`) |
+| Layout p95 | `<= 55ms` | auto (`benchmark:local50`) |
+| Timeline index p95 | `<= 60ms` | auto (`benchmark:local50`) |
+| Entity search p95 | `<= 12ms` | auto (`benchmark:local50`) |
+| Stream merge batch p95 | `<= 70ms` | auto (`benchmark:local50`) |
+| Memory footprint (`heapUsed`) | `<= 220MB` | auto (`benchmark:local50`) |
+| Render FPS | `>= 30` | manual probe |
+| Update latency (UI) | `<= 160ms` | manual probe |
+
+## Execution
+```bash
+pnpm benchmark:local50
+pnpm ci:local
+```
+
+## Reporting Template
+```md
+### Capacity Baseline Report - YYYY-MM-DD
+- Commit:
+- Machine:
+- Profile: local10 | local25 | local50
+
+| Metric | Budget | Result | Status |
+| --- | --- | --- | --- |
+| parseSessions p95 | <= 18ms |  |  |
+| parseRuns p95 | <= 45ms |  |  |
+| buildPlacements p95 | <= 55ms |  |  |
+| buildTimelineIndex p95 | <= 60ms |  |  |
+| searchEntityIds p95 | <= 12ms |  |  |
+| streamMerge p95 | <= 70ms |  |  |
+| heapUsed MB | <= 220MB |  |  |
+| FPS (manual) | >= 30 |  |  |
+| update latency (manual) | <= 160ms |  |  |
+```

--- a/docs/perf-local50.md
+++ b/docs/perf-local50.md
@@ -4,6 +4,7 @@
 - Operating mode: local-only (`127.0.0.1`)
 - Scenario size: `50 agents / 500 runs / 5,000 events`
 - Security hardening: out of scope for this benchmark pass
+- Baseline profiles (`10/25/50`) are defined in `docs/capacity-baseline.md`
 
 ## Budgets
 | Category | Budget |
@@ -17,12 +18,17 @@
 | Timeline index p95 | `<= 60ms` |
 | Entity search p95 | `<= 12ms` |
 | Stream merge batch p95 | `<= 70ms` |
+| Heap used (Node process) | `<= 220MB` |
 
 ## Commands
 ```bash
 pnpm benchmark:local50
 pnpm ci:local
 ```
+
+`benchmark:local50` automatically collects:
+- parse/layout/timeline/search/stream p95 metrics
+- Node `heapUsed` memory footprint
 
 ## Profiling Template
 Use this template when reporting a new measurement run.

--- a/src/lib/perf-budgets.ts
+++ b/src/lib/perf-budgets.ts
@@ -1,21 +1,76 @@
-export const LOCAL50_SCENARIO = {
-  agents: 50,
-  runs: 500,
-  events: 5_000,
-} as const;
+export type CapacityProfileId = "local10" | "local25" | "local50";
 
-// UX-oriented targets used as operating budgets for local 50-agent mode.
-export const LOCAL50_UX_BUDGET = {
-  minFps: 30,
-  ttiMs: 2_200,
-  updateLatencyMs: 160,
-} as const;
+export type CapacityScenario = {
+  agents: number;
+  runs: number;
+  events: number;
+};
 
-export const LOCAL50_PIPELINE_BUDGET = {
+export type CapacityUxBudget = {
+  minFps: number;
+  ttiMs: number;
+  updateLatencyMs: number;
+  memoryFootprintMb: number;
+};
+
+export type CapacityPipelineBudget = {
+  parseRunsP95Ms: number;
+  parseSessionsP95Ms: number;
+  layoutP95Ms: number;
+  timelineIndexP95Ms: number;
+  entitySearchP95Ms: number;
+  streamMergeBatchP95Ms: number;
+};
+
+export type CapacityProfile = {
+  scenario: CapacityScenario;
+  uxBudget: CapacityUxBudget;
+  pipelineBudget: CapacityPipelineBudget;
+};
+
+const BASELINE_PIPELINE_BUDGET: CapacityPipelineBudget = {
   parseRunsP95Ms: 45,
   parseSessionsP95Ms: 18,
   layoutP95Ms: 55,
   timelineIndexP95Ms: 60,
   entitySearchP95Ms: 12,
   streamMergeBatchP95Ms: 70,
+};
+
+const BASELINE_UX_BUDGET: CapacityUxBudget = {
+  minFps: 30,
+  ttiMs: 2_200,
+  updateLatencyMs: 160,
+  memoryFootprintMb: 220,
+};
+
+export const CAPACITY_BASELINE_PROFILES: Record<CapacityProfileId, CapacityProfile> = {
+  local10: {
+    scenario: { agents: 10, runs: 100, events: 1_000 },
+    uxBudget: BASELINE_UX_BUDGET,
+    pipelineBudget: BASELINE_PIPELINE_BUDGET,
+  },
+  local25: {
+    scenario: { agents: 25, runs: 250, events: 2_500 },
+    uxBudget: BASELINE_UX_BUDGET,
+    pipelineBudget: BASELINE_PIPELINE_BUDGET,
+  },
+  local50: {
+    scenario: { agents: 50, runs: 500, events: 5_000 },
+    uxBudget: BASELINE_UX_BUDGET,
+    pipelineBudget: BASELINE_PIPELINE_BUDGET,
+  },
+};
+
+export const LOCAL50_SCENARIO = {
+  ...CAPACITY_BASELINE_PROFILES.local50.scenario,
+} as const;
+
+// UX-oriented targets used as operating budgets for local 50-agent mode.
+export const LOCAL50_UX_BUDGET = {
+  ...CAPACITY_BASELINE_PROFILES.local50.uxBudget,
+} as const;
+
+export const LOCAL50_PIPELINE_BUDGET = {
+  ...CAPACITY_BASELINE_PROFILES.local50.pipelineBudget,
 } as const;


### PR DESCRIPTION
## Summary
- add a shared 10/25/50 capacity baseline document (`docs/capacity-baseline.md`) with fixture profiles and budget categories
- standardize baseline profile constants in `src/lib/perf-budgets.ts` and keep local50 exports derived from the shared profile
- extend `benchmark:local50` to auto-collect/assert Node heap footprint (`heapUsed`)
- link baseline policy in README and add a capacity-aligned GitHub issue template

## Validation
- pnpm ci:local

Closes #31
