### PR TITLE
[Stability] 메모리 Budget Guard + Backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ You can pass your own `x-correlation-id` request header to trace failures end-to
 - Reconnect/backfill:
   - client can resume with SSE `Last-Event-ID` or `?lastEventId=<seq>`
   - server keeps an in-memory lifecycle queue and replays missed frames after reconnect
+  - stream memory guard/backpressure counters are exposed via `GET /api/office/metrics`
 
 ## Kenney assets
 

--- a/docs/capacity-baseline.md
+++ b/docs/capacity-baseline.md
@@ -38,6 +38,12 @@ pnpm benchmark:local50
 pnpm ci:local
 ```
 
+## Soak Guard Signals
+During long-running stream checks, monitor `GET /api/office/metrics`:
+- `backpressureActivations`: how often burst throttling was applied
+- `droppedUnseenEvents`: lifecycle events intentionally dropped from incremental emission
+- `evictedBackfillEvents`: old backfill frames evicted to stay within queue budget
+
 ## Reporting Template
 ```md
 ### Capacity Baseline Report - YYYY-MM-DD

--- a/docs/perf-local50.md
+++ b/docs/perf-local50.md
@@ -31,6 +31,17 @@ pnpm ci:local
 - Node `heapUsed` memory footprint
 - report artifacts (`JSON`/`MD`): `.reports/perf/local50-latest.json`, `.reports/perf/local50-latest.md`
 
+## Stream Memory Guard
+`OfficeStreamBridge` applies a bounded queue and burst backpressure policy to keep memory usage stable:
+- `maxQueue`: cap lifecycle backfill queue size
+- `maxEmitPerSnapshot`: cap lifecycle frames emitted from a single snapshot burst
+- `maxSeen`: cap deduplication id set size
+
+Check `/api/office/metrics` stream counters during soak runs:
+- `backpressureActivations`
+- `droppedUnseenEvents`
+- `evictedBackfillEvents`
+
 ## Profiling Template
 Use this template when reporting a new measurement run.
 


### PR DESCRIPTION
## Summary
- add explicit stream memory guard/backpressure policy in `OfficeStreamBridge`
- expose pressure counters (`backpressureActivations`, `droppedUnseenEvents`, `evictedBackfillEvents`) via `/api/office/metrics`
- extend stream bridge tests with burst-drop and sustained ingest (soak-style) coverage
- document stream guard signals in perf/capacity docs and API section

## Validation
- `pnpm ci:local`

Closes #42
