### PR TITLE
[Planning] Roadmap Board + Release Readiness 운영 체계

### DIFF
--- a/.github/ISSUE_TEMPLATE/capacity-aligned-feature.yml
+++ b/.github/ISSUE_TEMPLATE/capacity-aligned-feature.yml
@@ -8,6 +8,40 @@ body:
     attributes:
       value: |
         Baseline reference: `docs/capacity-baseline.md`
+        Roadmap reference: `docs/roadmap-readiness.md`
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      description: Select exactly one roadmap phase.
+      options:
+        - foundation
+        - realtime
+        - visual
+        - ops
+        - scale
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - p0
+        - p1
+        - p2
+    validations:
+      required: true
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Effort
+      options:
+        - s
+        - m
+        - l
+    validations:
+      required: true
   - type: dropdown
     id: target_profile
     attributes:
@@ -18,6 +52,12 @@ body:
         - local50
     validations:
       required: true
+  - type: input
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Use issue numbers when blocked.
+      placeholder: "Depends on: #20, #30"
   - type: textarea
     id: objective
     attributes:
@@ -50,6 +90,8 @@ body:
       label: Definition of Done
       options:
         - label: This issue explicitly references docs/capacity-baseline.md
+          required: true
+        - label: This issue includes phase/priority/effort selection aligned with docs/roadmap-readiness.md
           required: true
         - label: Capacity metrics are collected and attached in the PR
           required: true

--- a/README.md
+++ b/README.md
@@ -200,4 +200,5 @@ A curation manifest is included at:
 - 50-agent 운영 한계를 기준으로 목표/완료조건 정의
 - 보안 이슈는 로컬 단독 사용 전제에서 우선순위 제외
 - capacity 관련 이슈는 `docs/capacity-baseline.md`를 명시적으로 참조
+- 로드맵/릴리즈 운영 기준은 `docs/roadmap-readiness.md`를 기준으로 관리
 - 신규 feature 이슈는 `.github/ISSUE_TEMPLATE/capacity-aligned-feature.yml` 템플릿 우선 사용

--- a/docs/roadmap-readiness.md
+++ b/docs/roadmap-readiness.md
@@ -1,0 +1,59 @@
+# Roadmap Board And Release Readiness
+
+## Scope
+- local-only operation (`127.0.0.1`)
+- max target capacity: 50 active agents
+- security hardening/compliance is out of scope for this roadmap board
+
+## Phase Board
+Use these phases to place every issue on one board lane.
+
+| Phase | Objective | Typical Outputs | Exit Signal |
+| --- | --- | --- | --- |
+| Foundation | deterministic fixtures, baseline budgets, local gates | generator, baseline docs, quality gate scripts | `pnpm ci:local` is reproducible |
+| Realtime | stream correctness and reconnect continuity | stream bridge, cursor/backfill, resilience handling | no timeline/state divergence on reconnect |
+| Visual | dense-scene readability and interaction quality | layout/timeline/stage UX features | operator can identify critical state quickly |
+| Ops | workflow acceleration for day-2 operation | command palette, alerts, reports, run knowledge | daily triage flow is tool-assisted end-to-end |
+| Scale | 25->50 readiness convergence and release decision | perf tuning, readiness gates, milestone checks | `v1-local50` gate can be judged objectively |
+
+## Labeling Rules
+Every new issue should include one value from each category.
+
+| Category | Allowed Values | Rule |
+| --- | --- | --- |
+| `phase/*` | `foundation`, `realtime`, `visual`, `ops`, `scale` | exactly 1 |
+| `priority/*` | `p0`, `p1`, `p2` | exactly 1 |
+| `effort/*` | `s`, `m`, `l` | exactly 1 |
+| dependency | `Depends on: #...` in issue body | required when blocked |
+
+If multiple dependencies exist, list them on one line:
+`Depends on: #20, #30, #40`
+
+## Unified DoD Template
+Copy this block to issue bodies.
+
+```md
+## Definition of Done
+- [ ] feature scope implemented
+- [ ] docs updated (`README` + related docs/*)
+- [ ] `pnpm ci:local` passed
+- [ ] capacity impact noted against `docs/capacity-baseline.md`
+- [ ] follow-up risks/backlog items recorded
+```
+
+## Release Smoke Scenarios
+Run before any release-readiness decision:
+
+1. `pnpm ci:local`
+2. `pnpm e2e:workflow`
+3. verify `.reports/perf/local50-latest.json` and `.reports/perf/local50-latest.md`
+4. confirm unresolved blocking issues and explicit risk log
+
+## Weekly Review Routine
+Run once per week with a fixed owner.
+
+1. Review open issues by dependency chain (blocked -> ready).
+2. Re-rank `priority/*` by operational risk and release impact.
+3. Move one phase lane forward only when exit signal is met.
+4. Record decisions and carry-over risks in the active milestone issue.
+5. Reconfirm that local-only constraints still hold (`127.0.0.1`, 50-agent target).


### PR DESCRIPTION
## Summary
- add roadmap/release readiness operating document (`docs/roadmap-readiness.md`)
  - phase lanes (Foundation/Realtime/Visual/Ops/Scale)
  - tagging rules (phase/priority/effort/dependency)
  - unified DoD template
  - release smoke sequence
  - weekly review routine
- extend issue template to capture phase/priority/effort/dependencies in a single intake form
- link roadmap-readiness policy from README issue policy section

## Validation
- `pnpm ci:local`

Closes #30
