### PR TITLE
feat: implement #18 command palette and shortcut system

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Web-based visual command center for OpenClaw agents and subagents.
 - Entity detail panel (`Overview / Sessions / Runs / Messages / Metrics`) with copy actions
 - Timeline debugger with `runId/agentId/status` filters + playback + run deep link
 - Multi-lane timeline groups (`room`, `agent`, `subagent`) with lane collapse + density summary
+- Command palette + global shortcuts with keymap override and recent command history
 
 ## Motion Lifecycle Guide
 
@@ -86,6 +87,7 @@ Web-based visual command center for OpenClaw agents and subagents.
 3. Focus mode 켜짐 상태에서 대상 식별(강조)과 비대상 dim이 명확
 4. 운영자 액션(`runId/sessionKey/log guide`) 성공/실패 토스트가 즉시 표시
 5. 선택/필터가 없는 실패 케이스에서도 안내 문구가 누락되지 않음
+6. Command Palette(`mod+k`)에서 핵심 액션 10개 이상 실행 가능하며 Shortcut Help에서 키맵 재설정 가능
 
 ## Data source
 

--- a/src/App.css
+++ b/src/App.css
@@ -1520,6 +1520,308 @@ body {
   padding: 10px 12px;
 }
 
+.command-palette-overlay,
+.shortcut-help-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1250;
+  background: rgba(2, 12, 20, 0.7);
+  backdrop-filter: blur(3px);
+  display: grid;
+  place-items: center;
+  padding: 14px;
+}
+
+.command-palette {
+  width: min(760px, 100%);
+  max-height: min(80vh, 820px);
+  border-radius: 18px;
+  border: 1px solid rgba(147, 226, 255, 0.35);
+  background: rgba(7, 27, 40, 0.96);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.4);
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.command-palette-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  border-bottom: 1px solid rgba(141, 220, 250, 0.24);
+}
+
+.command-palette-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.command-palette-header p {
+  margin: 5px 0 0;
+  color: #9accdb;
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.command-palette-header button {
+  align-self: flex-start;
+  border-radius: 999px;
+  border: 1px solid rgba(147, 226, 255, 0.4);
+  background: rgba(11, 44, 61, 0.9);
+  color: #dbf6ff;
+  font-size: 0.65rem;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.command-palette-search {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(141, 220, 250, 0.2);
+  display: grid;
+  gap: 5px;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #94cadd;
+}
+
+.command-palette-search input {
+  border-radius: 10px;
+  border: 1px solid rgba(146, 226, 255, 0.36);
+  background: rgba(7, 33, 49, 0.94);
+  color: #dcf6ff;
+  font-size: 0.78rem;
+  padding: 8px 10px;
+}
+
+.command-palette-empty {
+  margin: 0;
+  padding: 18px 12px;
+  color: #9bcddd;
+  font-size: 0.74rem;
+}
+
+.command-palette-list {
+  margin: 0;
+  padding: 8px;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+  overflow: auto;
+}
+
+.command-palette-item {
+  border: 1px solid rgba(136, 219, 255, 0.24);
+  border-radius: 10px;
+  background: rgba(7, 22, 34, 0.74);
+}
+
+.command-palette-item button {
+  border: 0;
+  background: transparent;
+  width: 100%;
+  text-align: left;
+  color: inherit;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: start;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.command-palette-item.is-active {
+  border-color: rgba(255, 221, 145, 0.65);
+  box-shadow: 0 0 0 1px rgba(255, 219, 131, 0.35);
+}
+
+.command-palette-item.is-disabled {
+  opacity: 0.5;
+}
+
+.command-palette-item.is-disabled button {
+  cursor: default;
+}
+
+.command-palette-label-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.command-palette-main strong {
+  font-size: 0.74rem;
+  letter-spacing: 0.03em;
+}
+
+.command-palette-main p {
+  margin: 5px 0 0;
+  font-size: 0.69rem;
+  line-height: 1.35;
+  color: #abd9e8;
+}
+
+.command-palette-section,
+.command-palette-recent {
+  border-radius: 999px;
+  border: 1px solid rgba(151, 228, 255, 0.34);
+  padding: 1px 7px;
+  font-size: 0.58rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #b9ecfb;
+}
+
+.command-palette-recent {
+  border-color: rgba(255, 219, 145, 0.5);
+  color: #ffe1ac;
+}
+
+.command-palette-item kbd {
+  align-self: center;
+  min-width: 56px;
+  text-align: center;
+  border-radius: 8px;
+  border: 1px solid rgba(152, 230, 255, 0.4);
+  background: rgba(10, 42, 59, 0.9);
+  color: #e0f8ff;
+  font-size: 0.63rem;
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  padding: 4px 7px;
+}
+
+.shortcut-help {
+  width: min(940px, 100%);
+  max-height: min(82vh, 860px);
+  border-radius: 18px;
+  border: 1px solid rgba(147, 226, 255, 0.35);
+  background: rgba(6, 24, 36, 0.98);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.4);
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.shortcut-help-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  border-bottom: 1px solid rgba(141, 220, 250, 0.24);
+}
+
+.shortcut-help-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.shortcut-help-header p {
+  margin: 5px 0 0;
+  color: #9accdb;
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.shortcut-help-header-actions {
+  display: inline-flex;
+  gap: 6px;
+  align-self: flex-start;
+}
+
+.shortcut-help-header-actions button {
+  border-radius: 999px;
+  border: 1px solid rgba(147, 226, 255, 0.4);
+  background: rgba(11, 44, 61, 0.9);
+  color: #dbf6ff;
+  font-size: 0.65rem;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.shortcut-help-header-actions button:disabled,
+.shortcut-help-actions button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.shortcut-help-capture {
+  margin: 0;
+  padding: 9px 12px;
+  font-size: 0.7rem;
+  color: #b9e5f4;
+  border-bottom: 1px solid rgba(141, 220, 250, 0.2);
+}
+
+.shortcut-help-list {
+  margin: 0;
+  padding: 8px;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+  overflow: auto;
+}
+
+.shortcut-help-item {
+  border: 1px solid rgba(136, 219, 255, 0.24);
+  border-radius: 10px;
+  background: rgba(7, 22, 34, 0.8);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 9px 10px;
+  align-items: center;
+}
+
+.shortcut-help-main strong {
+  display: block;
+  font-size: 0.74rem;
+}
+
+.shortcut-help-main p {
+  margin: 5px 0 0;
+  font-size: 0.69rem;
+  color: #abd9e8;
+}
+
+.shortcut-help-actions {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.shortcut-help-actions kbd {
+  border-radius: 8px;
+  border: 1px solid rgba(152, 230, 255, 0.4);
+  background: rgba(10, 42, 59, 0.9);
+  color: #e0f8ff;
+  font-size: 0.63rem;
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  min-width: 62px;
+  text-align: center;
+  padding: 4px 7px;
+}
+
+.shortcut-help-actions button {
+  border-radius: 8px;
+  border: 1px solid rgba(146, 226, 255, 0.35);
+  background: rgba(10, 40, 56, 0.88);
+  color: #d8f4ff;
+  font-size: 0.62rem;
+  padding: 5px 8px;
+  cursor: pointer;
+}
+
+.shortcut-help-actions button.is-armed {
+  border-color: rgba(255, 219, 145, 0.58);
+  color: #ffe4b0;
+}
+
 .ops-toast {
   position: fixed;
   right: 18px;
@@ -1729,5 +2031,30 @@ body {
     left: 10px;
     right: 10px;
     bottom: 10px;
+  }
+
+  .command-palette-overlay,
+  .shortcut-help-overlay {
+    padding: 8px;
+  }
+
+  .command-palette,
+  .shortcut-help {
+    max-height: 90vh;
+  }
+
+  .command-palette-header,
+  .shortcut-help-header {
+    flex-direction: column;
+  }
+
+  .command-palette-item button,
+  .shortcut-help-item {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .shortcut-help-actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,28 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import "./App.css";
+import { CommandPalette, type CommandPaletteEntry } from "./components/CommandPalette";
 import { EntityDetailPanel } from "./components/EntityDetailPanel";
 import { EventRail } from "./components/EventRail";
 import { OfficeStage } from "./components/OfficeStage";
 import { useOfficeStream } from "./hooks/useOfficeStream";
+import {
+  formatShortcut,
+  isEditableEventTarget,
+  keyboardEventToShortcut,
+  normalizeShortcut,
+  pushRecentCommand,
+  resolveShortcutForPlatform,
+  type ShortcutPlatform,
+} from "./lib/command-palette";
 import { buildEntitySearchIndex, searchEntityIds } from "./lib/entity-search";
 import type { PlacementMode } from "./lib/layout";
-import { parseRunIdDeepLink, type TimelineFilters } from "./lib/timeline";
+import {
+  buildTimelineIndex,
+  filterTimelineEvents,
+  nextPlaybackEventId,
+  parseRunIdDeepLink,
+  type TimelineFilters,
+} from "./lib/timeline";
 
 type EntityStatusFilter = "all" | "active" | "idle" | "error" | "ok" | "offline";
 type RecentWindowFilter = "all" | 5 | 15 | 30 | 60;
@@ -24,8 +40,86 @@ type ToastState = {
   message: string;
 } | null;
 
+type CommandSpec = {
+  id: string;
+  label: string;
+  description: string;
+  section: "Global" | "Filters" | "Timeline" | "Run Tools" | "Entities";
+  keywords?: string[];
+  defaultShortcut?: string;
+  allowInInput?: boolean;
+  allowWhenOverlayOpen?: boolean;
+  disabled?: boolean;
+  run: () => void | Promise<void>;
+};
+
+type CommandEntry = CommandSpec & {
+  effectiveShortcut: string;
+  shortcutLabel: string;
+};
+
+const SHORTCUT_OVERRIDES_KEY = "openclawoffice.shortcut-overrides.v1";
+const RECENT_COMMANDS_KEY = "openclawoffice.recent-commands.v1";
+const MAX_RECENT_COMMANDS = 8;
+
+const DEFAULT_OPS_FILTERS: OpsFilters = {
+  query: "",
+  status: "all",
+  roomId: "all",
+  placementMode: "auto",
+  recentMinutes: "all",
+  focusMode: false,
+};
+
 function quoteShellToken(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function detectShortcutPlatform(): ShortcutPlatform {
+  return /Mac|iPhone|iPad|iPod/i.test(window.navigator.platform) ? "mac" : "other";
+}
+
+function loadShortcutOverrides(): Record<string, string> {
+  try {
+    const raw = window.localStorage.getItem(SHORTCUT_OVERRIDES_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+
+    const normalizedOverrides: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value !== "string") {
+        continue;
+      }
+      const normalized = normalizeShortcut(value);
+      if (normalized) {
+        normalizedOverrides[key] = normalized;
+      }
+    }
+    return normalizedOverrides;
+  } catch {
+    return {};
+  }
+}
+
+function loadRecentCommands(): string[] {
+  try {
+    const raw = window.localStorage.getItem(RECENT_COMMANDS_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((value): value is string => typeof value === "string").slice(0, MAX_RECENT_COMMANDS);
+  } catch {
+    return [];
+  }
 }
 
 function StatCard(props: { label: string; value: number | string; accent?: string }) {
@@ -55,14 +149,18 @@ function App() {
     agentId: "",
     status: "all",
   }));
-  const [opsFilters, setOpsFilters] = useState<OpsFilters>({
-    query: "",
-    status: "all",
-    roomId: "all",
-    placementMode: "auto",
-    recentMinutes: "all",
-    focusMode: false,
-  });
+  const [opsFilters, setOpsFilters] = useState<OpsFilters>(DEFAULT_OPS_FILTERS);
+  const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
+  const [isShortcutHelpOpen, setIsShortcutHelpOpen] = useState(false);
+  const [rebindingCommandId, setRebindingCommandId] = useState<string | null>(null);
+  const [shortcutOverrides, setShortcutOverrides] = useState<Record<string, string>>(loadShortcutOverrides);
+  const [recentCommandIds, setRecentCommandIds] = useState<string[]>(loadRecentCommands);
+  const shortcutPlatform = useMemo(() => detectShortcutPlatform(), []);
+
+  const showToast = useCallback((kind: NonNullable<ToastState>["kind"], message: string) => {
+    setToast({ kind, message });
+  }, []);
+
   const searchIndex = useMemo(
     () => (snapshot ? buildEntitySearchIndex(snapshot) : new Map<string, string>()),
     [snapshot],
@@ -133,6 +231,19 @@ function App() {
     return null;
   }, [activeEvent, runById, selectedEntity, snapshot]);
 
+  const timelinePlaybackEvents = useMemo(() => {
+    if (!snapshot) {
+      return [];
+    }
+    const index = buildTimelineIndex(snapshot.events, snapshot.runGraph);
+    return [...filterTimelineEvents(index, timelineFilters)].sort((left, right) => left.at - right.at);
+  }, [snapshot, timelineFilters]);
+
+  const activeTimelineIndex = useMemo(
+    () => timelinePlaybackEvents.findIndex((event) => event.id === activeEventId),
+    [activeEventId, timelinePlaybackEvents],
+  );
+
   useEffect(() => {
     const url = new URL(window.location.href);
     const runId = timelineFilters.runId.trim();
@@ -156,6 +267,22 @@ function App() {
     };
   }, [toast]);
 
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(SHORTCUT_OVERRIDES_KEY, JSON.stringify(shortcutOverrides));
+    } catch {
+      // Ignore localStorage persistence errors in restricted browser modes.
+    }
+  }, [shortcutOverrides]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(RECENT_COMMANDS_KEY, JSON.stringify(recentCommandIds));
+    } catch {
+      // Ignore localStorage persistence errors in restricted browser modes.
+    }
+  }, [recentCommandIds]);
+
   const handleLaneContextChange = useCallback((next: { highlightAgentId: string | null }) => {
     setTimelineLaneHighlightAgentId(next.highlightAgentId);
   }, []);
@@ -163,6 +290,529 @@ function App() {
   const handleRoomAssignmentsChange = useCallback((next: Map<string, string>) => {
     setTimelineRoomByAgentId(next);
   }, []);
+
+  const copyText = useCallback(
+    async (text: string, successMessage: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        showToast("success", successMessage);
+      } catch (errorValue) {
+        console.warn("Clipboard copy failed", errorValue);
+        showToast("error", "Copy failed. Please check clipboard permission.");
+      }
+    },
+    [showToast],
+  );
+
+  const onCopyRunId = useCallback(async () => {
+    const runId = selectedRun?.runId ?? selectedEntity?.runId ?? activeEvent?.runId;
+    if (!runId) {
+      showToast("error", "No runId available. Select an entity or timeline event first.");
+      return;
+    }
+    await copyText(runId, `Copied runId: ${runId}`);
+  }, [activeEvent?.runId, copyText, selectedEntity?.runId, selectedRun?.runId, showToast]);
+
+  const onCopySessionKey = useCallback(async () => {
+    const sessionKey = selectedRun?.childSessionKey ?? selectedRun?.requesterSessionKey;
+    if (!sessionKey) {
+      showToast("error", "No session key available for the current context.");
+      return;
+    }
+    await copyText(sessionKey, "Copied session key.");
+  }, [copyText, selectedRun?.childSessionKey, selectedRun?.requesterSessionKey, showToast]);
+
+  const onCopyLogGuide = useCallback(async () => {
+    let agentId: string | null = null;
+    if (selectedEntity?.kind === "agent") {
+      agentId = selectedEntity.agentId;
+    } else if (selectedRun) {
+      agentId = selectedRun.childAgentId;
+    } else if (activeEvent) {
+      agentId = activeEvent.agentId;
+    }
+
+    if (!agentId || !snapshot) {
+      showToast("error", "No log path context. Select an entity or timeline event first.");
+      return;
+    }
+    const selectedLogPath = `${snapshot.source.stateDir}/agents/${agentId}/sessions`;
+    const guide = `cd -- ${quoteShellToken(selectedLogPath)}\nls -lt -- *.jsonl`;
+    await copyText(guide, "Copied log path guide.");
+  }, [activeEvent, copyText, selectedEntity, selectedRun, showToast, snapshot]);
+
+  const jumpToRunId = useCallback(
+    (runId: string, source: "toolbar" | "panel" = "toolbar") => {
+      setTimelineFilters((prev) => ({ ...prev, runId, status: "all" }));
+      setActiveEventId(null);
+      showToast(
+        "info",
+        source === "toolbar"
+          ? `Timeline jumped to runId filter: ${runId}`
+          : `Detail panel jumped to runId filter: ${runId}`,
+      );
+    },
+    [showToast],
+  );
+
+  const onJumpToRun = useCallback(() => {
+    const runId = selectedRun?.runId ?? selectedEntity?.runId ?? activeEvent?.runId;
+    if (!runId) {
+      showToast("error", "No runId available for jump.");
+      return;
+    }
+    jumpToRunId(runId, "toolbar");
+  }, [activeEvent?.runId, jumpToRunId, selectedEntity?.runId, selectedRun?.runId, showToast]);
+
+  const clearOpsFilters = useCallback(() => {
+    setOpsFilters(DEFAULT_OPS_FILTERS);
+    showToast("info", "Ops filters reset.");
+  }, [showToast]);
+
+  const clearTimelineFilters = useCallback(() => {
+    setTimelineFilters({ runId: "", agentId: "", status: "all" });
+    setActiveEventId(null);
+    showToast("info", "Timeline filters reset.");
+  }, [showToast]);
+
+  const moveTimelineEvent = useCallback(
+    (direction: 1 | -1) => {
+      const nextId = nextPlaybackEventId(timelinePlaybackEvents, activeEventId, direction);
+      if (!nextId) {
+        showToast(
+          "info",
+          direction === 1 ? "Already at the latest timeline event." : "Already at the earliest timeline event.",
+        );
+        return;
+      }
+      setActiveEventId(nextId);
+    },
+    [activeEventId, showToast, timelinePlaybackEvents],
+  );
+
+  const togglePlacementMode = useCallback(() => {
+    setOpsFilters((prev) => ({
+      ...prev,
+      placementMode: prev.placementMode === "auto" ? "manual" : "auto",
+    }));
+  }, []);
+
+  const toggleFocusMode = useCallback(() => {
+    setOpsFilters((prev) => ({ ...prev, focusMode: !prev.focusMode }));
+  }, []);
+
+  const toggleCommandPalette = useCallback(() => {
+    setRebindingCommandId(null);
+    setIsShortcutHelpOpen(false);
+    setIsCommandPaletteOpen((prev) => !prev);
+  }, []);
+
+  const openShortcutHelp = useCallback(() => {
+    setRebindingCommandId(null);
+    setIsCommandPaletteOpen(false);
+    setIsShortcutHelpOpen(true);
+  }, []);
+
+  const closeShortcutHelp = useCallback(() => {
+    setRebindingCommandId(null);
+    setIsShortcutHelpOpen(false);
+  }, []);
+
+  const entityCommandSpecs = useMemo<CommandSpec[]>(() => {
+    if (!snapshot) {
+      return [];
+    }
+    return [...snapshot.entities]
+      .sort((left, right) => left.agentId.localeCompare(right.agentId))
+      .map((entity) => ({
+        id: `entity.jump:${entity.id}`,
+        label: `Jump to ${entity.kind} ${entity.agentId}`,
+        description: `Select ${entity.id} and open detail context in the panel.`,
+        section: "Entities",
+        keywords: [entity.id, entity.agentId, entity.runId ?? "", entity.status, entity.kind],
+        run: () => {
+          setSelectedEntityId(entity.id);
+          showToast("info", `Selected ${entity.kind} ${entity.agentId}`);
+        },
+      }));
+  }, [showToast, snapshot]);
+
+  const baseCommandSpecs = useMemo<CommandSpec[]>(
+    () => [
+      {
+        id: "palette.toggle",
+        label: "Toggle Command Palette",
+        description: "Open or close the command palette.",
+        section: "Global",
+        defaultShortcut: "mod+k",
+        allowInInput: true,
+        allowWhenOverlayOpen: true,
+        keywords: ["command", "palette", "search"],
+        run: toggleCommandPalette,
+      },
+      {
+        id: "help.shortcuts",
+        label: "Open Shortcut Help",
+        description: "Open cheat sheet and edit keymap overrides.",
+        section: "Global",
+        defaultShortcut: "shift+/",
+        allowInInput: true,
+        allowWhenOverlayOpen: true,
+        keywords: ["cheat", "keymap", "shortcut", "help"],
+        run: openShortcutHelp,
+      },
+      {
+        id: "filters.clear",
+        label: "Clear Ops Filters",
+        description: "Reset search, status, room, recent, focus, and placement filters.",
+        section: "Filters",
+        defaultShortcut: "mod+shift+x",
+        keywords: ["clear", "reset", "ops"],
+        run: clearOpsFilters,
+      },
+      {
+        id: "filters.focus.toggle",
+        label: "Toggle Focus Mode",
+        description: "Toggle stage focus lighting for selected context.",
+        section: "Filters",
+        defaultShortcut: "mod+f",
+        keywords: ["focus", "lighting", "fog"],
+        run: toggleFocusMode,
+      },
+      {
+        id: "filters.status.all",
+        label: "Set Status Filter: ALL",
+        description: "Show every entity status in the stage.",
+        section: "Filters",
+        defaultShortcut: "mod+0",
+        keywords: ["status", "all"],
+        run: () => {
+          setOpsFilters((prev) => ({ ...prev, status: "all" }));
+        },
+      },
+      {
+        id: "filters.status.active",
+        label: "Set Status Filter: ACTIVE",
+        description: "Show active entities only.",
+        section: "Filters",
+        defaultShortcut: "mod+1",
+        keywords: ["status", "active"],
+        run: () => {
+          setOpsFilters((prev) => ({ ...prev, status: "active" }));
+        },
+      },
+      {
+        id: "filters.status.error",
+        label: "Set Status Filter: ERROR",
+        description: "Show error entities only.",
+        section: "Filters",
+        defaultShortcut: "mod+2",
+        keywords: ["status", "error"],
+        run: () => {
+          setOpsFilters((prev) => ({ ...prev, status: "error" }));
+        },
+      },
+      {
+        id: "layout.placement.toggle",
+        label: "Toggle Placement Mode",
+        description: "Switch between AUTO and MANUAL overflow routing.",
+        section: "Filters",
+        defaultShortcut: "mod+m",
+        keywords: ["placement", "auto", "manual", "overflow"],
+        run: togglePlacementMode,
+      },
+      {
+        id: "timeline.clear",
+        label: "Clear Timeline Filters",
+        description: "Reset run/agent/status timeline filters and playback cursor.",
+        section: "Timeline",
+        defaultShortcut: "alt+shift+c",
+        keywords: ["timeline", "clear", "reset"],
+        run: clearTimelineFilters,
+      },
+      {
+        id: "timeline.prev",
+        label: "Timeline Previous Event",
+        description: "Move playback cursor to previous timeline event.",
+        section: "Timeline",
+        defaultShortcut: "alt+arrowleft",
+        keywords: ["timeline", "previous", "playback"],
+        run: () => {
+          moveTimelineEvent(-1);
+        },
+      },
+      {
+        id: "timeline.next",
+        label: "Timeline Next Event",
+        description: "Move playback cursor to next timeline event.",
+        section: "Timeline",
+        defaultShortcut: "alt+arrowright",
+        keywords: ["timeline", "next", "playback"],
+        run: () => {
+          moveTimelineEvent(1);
+        },
+      },
+      {
+        id: "run.jump",
+        label: "Jump to Selected Run",
+        description: "Apply selected runId to timeline filter.",
+        section: "Run Tools",
+        defaultShortcut: "mod+j",
+        keywords: ["run", "jump", "timeline"],
+        run: onJumpToRun,
+      },
+      {
+        id: "run.copy.runId",
+        label: "Copy runId",
+        description: "Copy runId from selected entity/timeline context.",
+        section: "Run Tools",
+        defaultShortcut: "mod+shift+r",
+        keywords: ["copy", "run", "id"],
+        run: () => {
+          void onCopyRunId();
+        },
+      },
+      {
+        id: "run.copy.sessionKey",
+        label: "Copy sessionKey",
+        description: "Copy requester/child session key from current run.",
+        section: "Run Tools",
+        defaultShortcut: "mod+shift+s",
+        keywords: ["copy", "session", "key"],
+        run: () => {
+          void onCopySessionKey();
+        },
+      },
+      {
+        id: "run.copy.logGuide",
+        label: "Copy Log Path Guide",
+        description: "Copy shell snippet for selected agent session log directory.",
+        section: "Run Tools",
+        defaultShortcut: "mod+shift+g",
+        keywords: ["copy", "log", "path", "guide"],
+        run: () => {
+          void onCopyLogGuide();
+        },
+      },
+    ],
+    [
+      clearOpsFilters,
+      clearTimelineFilters,
+      moveTimelineEvent,
+      onCopyLogGuide,
+      onCopyRunId,
+      onCopySessionKey,
+      onJumpToRun,
+      openShortcutHelp,
+      toggleCommandPalette,
+      toggleFocusMode,
+      togglePlacementMode,
+    ],
+  );
+
+  const commandSpecs = useMemo(() => [...baseCommandSpecs, ...entityCommandSpecs], [
+    baseCommandSpecs,
+    entityCommandSpecs,
+  ]);
+
+  const defaultShortcutByCommandId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const command of commandSpecs) {
+      if (!command.defaultShortcut) {
+        continue;
+      }
+      const normalized = normalizeShortcut(command.defaultShortcut);
+      if (normalized) {
+        map.set(command.id, normalized);
+      }
+    }
+    return map;
+  }, [commandSpecs]);
+
+  const commandEntries = useMemo<CommandEntry[]>(() => {
+    return commandSpecs.map((command) => {
+      const overrideShortcut = shortcutOverrides[command.id];
+      const baseShortcut = overrideShortcut ?? command.defaultShortcut;
+      const normalizedShortcut = baseShortcut ? normalizeShortcut(baseShortcut) : null;
+      const effectiveShortcut = normalizedShortcut
+        ? (resolveShortcutForPlatform(normalizedShortcut, shortcutPlatform) ?? "")
+        : "";
+      const shortcutLabel = normalizedShortcut ? formatShortcut(normalizedShortcut, shortcutPlatform) : "";
+      return {
+        ...command,
+        effectiveShortcut,
+        shortcutLabel,
+      };
+    });
+  }, [commandSpecs, shortcutOverrides, shortcutPlatform]);
+
+  const commandEntryById = useMemo(
+    () => new Map(commandEntries.map((entry) => [entry.id, entry])),
+    [commandEntries],
+  );
+
+  const shortcutCommands = useMemo(
+    () => commandEntries.filter((command) => Boolean(command.defaultShortcut)),
+    [commandEntries],
+  );
+
+  const paletteCommands = useMemo<CommandPaletteEntry[]>(
+    () =>
+      commandEntries.map((command) => ({
+        id: command.id,
+        label: command.label,
+        description: command.description,
+        section: command.section,
+        keywords: command.keywords,
+        shortcutLabel: command.shortcutLabel,
+        disabled: command.disabled,
+      })),
+    [commandEntries],
+  );
+
+  const executeCommandById = useCallback(
+    (commandId: string, source: "palette" | "shortcut") => {
+      const command = commandEntryById.get(commandId);
+      if (!command || command.disabled) {
+        return;
+      }
+      const result = command.run();
+      if (result instanceof Promise) {
+        void result;
+      }
+
+      if (!command.id.startsWith("palette.") && !command.id.startsWith("help.")) {
+        setRecentCommandIds((prev) => pushRecentCommand(prev, command.id, MAX_RECENT_COMMANDS));
+      }
+
+      if (source === "palette") {
+        setIsCommandPaletteOpen(false);
+      }
+    },
+    [commandEntryById],
+  );
+
+  useEffect(() => {
+    const handleShortcut = (event: KeyboardEvent) => {
+      if (rebindingCommandId) {
+        return;
+      }
+      const chord = keyboardEventToShortcut(event);
+      if (!chord) {
+        return;
+      }
+
+      const isInputTarget = isEditableEventTarget(event.target);
+      const isOverlayOpen = isCommandPaletteOpen || isShortcutHelpOpen;
+
+      const matchedCommand = commandEntries.find((command) => {
+        if (!command.effectiveShortcut || command.disabled) {
+          return false;
+        }
+        if (command.effectiveShortcut !== chord) {
+          return false;
+        }
+        if (isInputTarget && !command.allowInInput) {
+          return false;
+        }
+        if (isOverlayOpen && !command.allowWhenOverlayOpen) {
+          return false;
+        }
+        return true;
+      });
+
+      if (!matchedCommand) {
+        return;
+      }
+
+      event.preventDefault();
+      executeCommandById(matchedCommand.id, "shortcut");
+    };
+
+    window.addEventListener("keydown", handleShortcut);
+    return () => {
+      window.removeEventListener("keydown", handleShortcut);
+    };
+  }, [
+    commandEntries,
+    executeCommandById,
+    isCommandPaletteOpen,
+    isShortcutHelpOpen,
+    rebindingCommandId,
+  ]);
+
+  const resetShortcutOverride = useCallback(
+    (commandId: string) => {
+      setShortcutOverrides((prev) => {
+        if (!(commandId in prev)) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[commandId];
+        return next;
+      });
+    },
+    [setShortcutOverrides],
+  );
+
+  useEffect(() => {
+    if (!isShortcutHelpOpen || !rebindingCommandId) {
+      return undefined;
+    }
+
+    const handleRebind = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setRebindingCommandId(null);
+        return;
+      }
+
+      const chord = keyboardEventToShortcut(event);
+      if (!chord) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const conflict = shortcutCommands.find(
+        (command) => command.id !== rebindingCommandId && command.effectiveShortcut === chord,
+      );
+      if (conflict) {
+        showToast("error", `Shortcut conflict: ${conflict.label}`);
+        return;
+      }
+
+      const normalizedChord = normalizeShortcut(chord);
+      if (!normalizedChord) {
+        return;
+      }
+
+      setShortcutOverrides((prev) => {
+        const next = { ...prev };
+        const defaultShortcut = defaultShortcutByCommandId.get(rebindingCommandId);
+        if (defaultShortcut === normalizedChord) {
+          delete next[rebindingCommandId];
+        } else {
+          next[rebindingCommandId] = normalizedChord;
+        }
+        return next;
+      });
+
+      setRebindingCommandId(null);
+      showToast("success", "Shortcut updated.");
+    };
+
+    window.addEventListener("keydown", handleRebind);
+    return () => {
+      window.removeEventListener("keydown", handleRebind);
+    };
+  }, [
+    defaultShortcutByCommandId,
+    isShortcutHelpOpen,
+    rebindingCommandId,
+    shortcutCommands,
+    showToast,
+  ]);
 
   if (!snapshot) {
     return (
@@ -191,76 +841,8 @@ function App() {
     opsFilters.roomId !== "all" ||
     opsFilters.recentMinutes !== "all";
 
-  const showToast = (kind: NonNullable<ToastState>["kind"], message: string) => {
-    setToast({ kind, message });
-  };
-
-  const copyText = async (text: string, successMessage: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      showToast("success", successMessage);
-    } catch (errorValue) {
-      console.warn("Clipboard copy failed", errorValue);
-      showToast("error", "Copy failed. Please check clipboard permission.");
-    }
-  };
-
-  const onCopyRunId = async () => {
-    const runId = selectedRun?.runId ?? selectedEntity?.runId ?? activeEvent?.runId;
-    if (!runId) {
-      showToast("error", "No runId available. Select an entity or timeline event first.");
-      return;
-    }
-    await copyText(runId, `Copied runId: ${runId}`);
-  };
-
-  const onCopySessionKey = async () => {
-    const sessionKey = selectedRun?.childSessionKey ?? selectedRun?.requesterSessionKey;
-    if (!sessionKey) {
-      showToast("error", "No session key available for the current context.");
-      return;
-    }
-    await copyText(sessionKey, "Copied session key.");
-  };
-
-  const onCopyLogGuide = async () => {
-    let agentId: string | null = null;
-    if (selectedEntity?.kind === "agent") {
-      agentId = selectedEntity.agentId;
-    } else if (selectedRun) {
-      agentId = selectedRun.childAgentId;
-    } else if (activeEvent) {
-      agentId = activeEvent.agentId;
-    }
-
-    if (!agentId) {
-      showToast("error", "No log path context. Select an entity or timeline event first.");
-      return;
-    }
-    const selectedLogPath = `${snapshot.source.stateDir}/agents/${agentId}/sessions`;
-    const guide = `cd -- ${quoteShellToken(selectedLogPath)}\nls -lt -- *.jsonl`;
-    await copyText(guide, "Copied log path guide.");
-  };
-
-  const jumpToRunId = (runId: string, source: "toolbar" | "panel" = "toolbar") => {
-    setTimelineFilters((prev) => ({ ...prev, runId, status: "all" }));
-    setActiveEventId(null);
-    showToast(
-      "info",
-      source === "toolbar"
-        ? `Timeline jumped to runId filter: ${runId}`
-        : `Detail panel jumped to runId filter: ${runId}`,
-    );
-  };
-
-  const onJumpToRun = () => {
-    const runId = selectedRun?.runId ?? selectedEntity?.runId ?? activeEvent?.runId;
-    if (!runId) {
-      showToast("error", "No runId available for jump.");
-      return;
-    }
-    jumpToRunId(runId, "toolbar");
-  };
+  const paletteShortcutLabel = formatShortcut("mod+k", shortcutPlatform);
+  const helpShortcutLabel = formatShortcut("shift+/", shortcutPlatform);
 
   return (
     <main className="app-shell">
@@ -387,6 +969,12 @@ function App() {
         </label>
 
         <div className="ops-actions">
+          <button type="button" onClick={toggleCommandPalette}>
+            Command Palette ({paletteShortcutLabel})
+          </button>
+          <button type="button" onClick={openShortcutHelp}>
+            Shortcut Help ({helpShortcutLabel})
+          </button>
           <button type="button" onClick={() => void onCopyRunId()}>
             Copy runId
           </button>
@@ -457,10 +1045,7 @@ function App() {
           <strong>Data Warnings ({snapshot.diagnostics.length})</strong>
           <ul>
             {diagnostics.map((diagnostic, index) => (
-              <li
-                key={`${diagnostic.code}:${diagnostic.source}:${index}`}
-                title={diagnostic.message}
-              >
+              <li key={`${diagnostic.code}:${diagnostic.source}:${index}`} title={diagnostic.message}>
                 [{diagnostic.code}] {diagnostic.source}
               </li>
             ))}
@@ -470,8 +1055,106 @@ function App() {
 
       <footer className="footer-bar">
         <span>State Dir: {snapshot.source.stateDir}</span>
-        <span>Updated: {new Date(snapshot.generatedAt).toLocaleTimeString()}</span>
+        <span>
+          Updated: {new Date(snapshot.generatedAt).toLocaleTimeString()} | timeline
+          {" "}
+          {activeTimelineIndex >= 0 ? activeTimelineIndex + 1 : 0}/{timelinePlaybackEvents.length}
+        </span>
       </footer>
+
+      {isCommandPaletteOpen ? (
+        <CommandPalette
+          commands={paletteCommands}
+          recentCommandIds={recentCommandIds}
+          onClose={() => {
+            setIsCommandPaletteOpen(false);
+          }}
+          onExecute={(commandId) => {
+            executeCommandById(commandId, "palette");
+          }}
+          onOpenHelp={openShortcutHelp}
+        />
+      ) : null}
+
+      {isShortcutHelpOpen ? (
+        <div
+          className="shortcut-help-overlay"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) {
+              closeShortcutHelp();
+            }
+          }}
+        >
+          <section className="shortcut-help" role="dialog" aria-modal="true" aria-label="Shortcut Help">
+            <header className="shortcut-help-header">
+              <div>
+                <h2>Shortcut Help</h2>
+                <p>
+                  Rebind keys for command actions. Press a key combination after clicking Rebind.
+                </p>
+              </div>
+              <div className="shortcut-help-header-actions">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShortcutOverrides({});
+                    setRebindingCommandId(null);
+                    showToast("info", "All shortcut overrides reset.");
+                  }}
+                  disabled={Object.keys(shortcutOverrides).length === 0}
+                >
+                  Reset all
+                </button>
+                <button type="button" onClick={closeShortcutHelp}>
+                  Close
+                </button>
+              </div>
+            </header>
+
+            <p className="shortcut-help-capture" aria-live="polite">
+              {rebindingCommandId
+                ? `Listening for new shortcut: ${commandEntryById.get(rebindingCommandId)?.label ?? rebindingCommandId}`
+                : "Select Rebind on a command to capture a new shortcut. Press Esc to cancel capture."}
+            </p>
+
+            <ol className="shortcut-help-list">
+              {shortcutCommands.map((command) => {
+                const hasOverride = Boolean(shortcutOverrides[command.id]);
+                return (
+                  <li key={command.id} className="shortcut-help-item">
+                    <div className="shortcut-help-main">
+                      <strong>{command.label}</strong>
+                      <p>{command.description}</p>
+                    </div>
+                    <div className="shortcut-help-actions">
+                      <kbd>{command.shortcutLabel}</kbd>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setRebindingCommandId(command.id);
+                        }}
+                        className={rebindingCommandId === command.id ? "is-armed" : ""}
+                      >
+                        {rebindingCommandId === command.id ? "Press keys..." : "Rebind"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          resetShortcutOverride(command.id);
+                        }}
+                        disabled={!hasOverride}
+                      >
+                        Reset
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ol>
+          </section>
+        </div>
+      ) : null}
 
       {toast ? (
         <div className={`ops-toast ${toast.kind}`} role="status" aria-live="polite">

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { filterCommandIds } from "../lib/command-palette";
+
+export type CommandPaletteEntry = {
+  id: string;
+  label: string;
+  description: string;
+  section: string;
+  shortcutLabel: string;
+  keywords?: string[];
+  disabled?: boolean;
+};
+
+type Props = {
+  commands: CommandPaletteEntry[];
+  recentCommandIds: string[];
+  onClose: () => void;
+  onExecute: (commandId: string) => void;
+  onOpenHelp: () => void;
+};
+
+export function CommandPalette({
+  commands,
+  recentCommandIds,
+  onClose,
+  onExecute,
+  onOpenHelp,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const commandById = useMemo(
+    () => new Map(commands.map((command) => [command.id, command])),
+    [commands],
+  );
+
+  const filteredIds = useMemo(
+    () =>
+      filterCommandIds(
+        commands.map((command) => ({
+          id: command.id,
+          label: command.label,
+          description: command.description,
+          keywords: command.keywords,
+        })),
+        query,
+      ),
+    [commands, query],
+  );
+
+  const visibleCommands = useMemo(
+    () => filteredIds.map((id) => commandById.get(id)).filter((value): value is CommandPaletteEntry => Boolean(value)),
+    [commandById, filteredIds],
+  );
+
+  const orderedCommands = useMemo(() => {
+    if (query.trim()) {
+      return visibleCommands;
+    }
+    const recent = recentCommandIds
+      .map((id) => commandById.get(id))
+      .filter((value): value is CommandPaletteEntry => Boolean(value));
+    const recentSet = new Set(recent.map((entry) => entry.id));
+    const rest = visibleCommands.filter((entry) => !recentSet.has(entry.id));
+    return [...recent, ...rest];
+  }, [commandById, query, recentCommandIds, visibleCommands]);
+
+  const activeCommandIndex =
+    orderedCommands.length === 0 ? 0 : Math.min(activeIndex, orderedCommands.length - 1);
+
+  useEffect(() => {
+    window.setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((current) => {
+          if (orderedCommands.length === 0) {
+            return 0;
+          }
+          return (current + 1) % orderedCommands.length;
+        });
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((current) => {
+          if (orderedCommands.length === 0) {
+            return 0;
+          }
+          return (current - 1 + orderedCommands.length) % orderedCommands.length;
+        });
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const selectedCommand = orderedCommands[activeCommandIndex];
+        if (!selectedCommand || selectedCommand.disabled) {
+          return;
+        }
+        event.preventDefault();
+        onExecute(selectedCommand.id);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeCommandIndex, onClose, onExecute, orderedCommands]);
+
+  return (
+    <div
+      className="command-palette-overlay"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <section className="command-palette" role="dialog" aria-modal="true" aria-label="Command Palette">
+        <header className="command-palette-header">
+          <div>
+            <h2>Command Palette</h2>
+            <p>Search commands, jump entities, and run keyboard actions.</p>
+          </div>
+          <button type="button" onClick={onOpenHelp}>
+            Shortcut Help
+          </button>
+        </header>
+
+        <label className="command-palette-search">
+          Find command
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            placeholder="Search by command, shortcut, or keyword..."
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setActiveIndex(0);
+            }}
+          />
+        </label>
+
+        {orderedCommands.length === 0 ? (
+          <p className="command-palette-empty">No commands match this query.</p>
+        ) : (
+          <ol className="command-palette-list">
+            {orderedCommands.map((command, index) => {
+              const isRecent = !query.trim() && recentCommandIds.includes(command.id);
+              return (
+                <li
+                  key={command.id}
+                  className={`command-palette-item ${index === activeCommandIndex ? "is-active" : ""} ${
+                    command.disabled ? "is-disabled" : ""
+                  }`}
+                >
+                  <button
+                    type="button"
+                    disabled={command.disabled}
+                    onMouseEnter={() => {
+                      setActiveIndex(index);
+                    }}
+                    onClick={() => {
+                      onExecute(command.id);
+                    }}
+                  >
+                    <div className="command-palette-main">
+                      <div className="command-palette-label-row">
+                        <strong>{command.label}</strong>
+                        <span className="command-palette-section">{command.section}</span>
+                        {isRecent ? <span className="command-palette-recent">Recent</span> : null}
+                      </div>
+                      <p>{command.description}</p>
+                    </div>
+                    <kbd>{command.shortcutLabel || "-"}</kbd>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/lib/command-palette.test.ts
+++ b/src/lib/command-palette.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterCommandIds,
+  formatShortcut,
+  keyboardEventToShortcut,
+  normalizeShortcut,
+  pushRecentCommand,
+  resolveShortcutForPlatform,
+  shortcutMatchesEvent,
+} from "./command-palette";
+
+function shortcutEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    key: "",
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+describe("shortcut normalization", () => {
+  it("normalizes modifier aliases and token order", () => {
+    expect(normalizeShortcut("shift + cmd + K")).toBe("meta+shift+k");
+    expect(normalizeShortcut("control+alt+ArrowRight")).toBe("ctrl+alt+arrowright");
+  });
+
+  it("converts question token into slash + shift", () => {
+    expect(normalizeShortcut("mod+?")).toBe("mod+shift+/");
+  });
+
+  it("returns null on invalid shortcut strings", () => {
+    expect(normalizeShortcut("")).toBeNull();
+    expect(normalizeShortcut("cmd+ctrl")).toBeNull();
+    expect(normalizeShortcut("cmd+alt+foo+bar")).toBeNull();
+  });
+});
+
+describe("shortcut platform resolution", () => {
+  it("resolves mod token based on platform", () => {
+    expect(resolveShortcutForPlatform("mod+k", "mac")).toBe("meta+k");
+    expect(resolveShortcutForPlatform("mod+k", "other")).toBe("ctrl+k");
+  });
+});
+
+describe("keyboard event matching", () => {
+  it("normalizes keyboard events into shortcut chords", () => {
+    expect(
+      keyboardEventToShortcut(
+        shortcutEvent({
+          key: "?",
+          code: "Slash",
+          shiftKey: true,
+        }),
+      ),
+    ).toBe("shift+/");
+
+    expect(
+      keyboardEventToShortcut(
+        shortcutEvent({
+          key: "k",
+          code: "KeyK",
+          metaKey: true,
+        }),
+      ),
+    ).toBe("meta+k");
+  });
+
+  it("matches resolved shortcuts with events", () => {
+    const event = shortcutEvent({
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+    });
+    expect(shortcutMatchesEvent("mod+k", event, "other")).toBe(true);
+    expect(shortcutMatchesEvent("mod+k", event, "mac")).toBe(false);
+  });
+});
+
+describe("shortcut display labels", () => {
+  it("formats shortcuts for mac and non-mac layouts", () => {
+    expect(formatShortcut("mod+shift+k", "mac")).toBe("⌘⇧K");
+    expect(formatShortcut("mod+shift+k", "other")).toBe("Ctrl+Shift+K");
+  });
+});
+
+describe("command palette helpers", () => {
+  it("filters commands by label/description/keywords/id", () => {
+    const ids = filterCommandIds(
+      [
+        {
+          id: "filters.clear",
+          label: "Clear Filters",
+          description: "Reset all ops filters",
+          keywords: ["reset", "ops"],
+        },
+        {
+          id: "timeline.next",
+          label: "Timeline Next Event",
+          description: "Move to the next event in playback order",
+          keywords: ["timeline", "playback"],
+        },
+      ],
+      "next playback",
+    );
+    expect(ids).toEqual(["timeline.next"]);
+  });
+
+  it("tracks recent commands with de-duplication and max length", () => {
+    expect(pushRecentCommand(["b", "a"], "b", 4)).toEqual(["b", "a"]);
+    expect(pushRecentCommand(["d", "c", "b", "a"], "x", 3)).toEqual(["x", "d", "c"]);
+  });
+});

--- a/src/lib/command-palette.ts
+++ b/src/lib/command-palette.ts
@@ -1,0 +1,370 @@
+export type ShortcutPlatform = "mac" | "other";
+
+export type ShortcutEvent = Pick<
+  KeyboardEvent,
+  "key" | "code" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+>;
+
+export type CommandSearchEntry = {
+  id: string;
+  label: string;
+  description?: string;
+  keywords?: string[];
+};
+
+const MODIFIER_ORDER_WITH_MOD = ["mod", "ctrl", "meta", "alt", "shift"] as const;
+const MODIFIER_ORDER = ["ctrl", "meta", "alt", "shift"] as const;
+const MODIFIER_KEYS = new Set<string>(["shift", "ctrl", "control", "alt", "meta"]);
+
+const SHORTCUT_MODIFIER_ALIASES = new Map<string, (typeof MODIFIER_ORDER_WITH_MOD)[number]>([
+  ["mod", "mod"],
+  ["ctrl", "ctrl"],
+  ["control", "ctrl"],
+  ["cmd", "meta"],
+  ["command", "meta"],
+  ["meta", "meta"],
+  ["alt", "alt"],
+  ["option", "alt"],
+  ["shift", "shift"],
+]);
+
+const KEY_SYNONYMS = new Map<string, string>([
+  ["esc", "escape"],
+  ["return", "enter"],
+  ["spacebar", "space"],
+  ["del", "delete"],
+  ["up", "arrowup"],
+  ["down", "arrowdown"],
+  ["left", "arrowleft"],
+  ["right", "arrowright"],
+]);
+
+const CODE_TO_KEY = new Map<string, string>([
+  ["Space", "space"],
+  ["Slash", "/"],
+  ["Backslash", "\\"],
+  ["BracketLeft", "["],
+  ["BracketRight", "]"],
+  ["Minus", "-"],
+  ["Equal", "="],
+  ["Comma", ","],
+  ["Period", "."],
+  ["Semicolon", ";"],
+  ["Quote", "'"],
+  ["Backquote", "`"],
+  ["Escape", "escape"],
+  ["Enter", "enter"],
+  ["Tab", "tab"],
+  ["Backspace", "backspace"],
+  ["Delete", "delete"],
+  ["ArrowUp", "arrowup"],
+  ["ArrowDown", "arrowdown"],
+  ["ArrowLeft", "arrowleft"],
+  ["ArrowRight", "arrowright"],
+  ["Home", "home"],
+  ["End", "end"],
+  ["PageUp", "pageup"],
+  ["PageDown", "pagedown"],
+]);
+
+const DISPLAY_KEY_LABEL = new Map<string, string>([
+  ["space", "Space"],
+  ["escape", "Esc"],
+  ["enter", "Enter"],
+  ["tab", "Tab"],
+  ["backspace", "Backspace"],
+  ["delete", "Del"],
+  ["arrowup", "Up"],
+  ["arrowdown", "Down"],
+  ["arrowleft", "Left"],
+  ["arrowright", "Right"],
+  ["pageup", "PgUp"],
+  ["pagedown", "PgDn"],
+  ["home", "Home"],
+  ["end", "End"],
+]);
+
+const DISPLAY_KEY_LABEL_MAC = new Map<string, string>([
+  ["arrowup", "↑"],
+  ["arrowdown", "↓"],
+  ["arrowleft", "←"],
+  ["arrowright", "→"],
+  ["delete", "⌦"],
+  ["backspace", "⌫"],
+  ["space", "Space"],
+  ["enter", "↩"],
+  ["tab", "⇥"],
+  ["escape", "Esc"],
+]);
+
+const SPECIAL_KEYS = new Set<string>([
+  "space",
+  "escape",
+  "enter",
+  "tab",
+  "backspace",
+  "delete",
+  "arrowup",
+  "arrowdown",
+  "arrowleft",
+  "arrowright",
+  "home",
+  "end",
+  "pageup",
+  "pagedown",
+]);
+
+function canonicalizeShortcut(
+  modifiers: Iterable<string>,
+  key: string,
+  includeMod: boolean,
+): string {
+  const modifierSet = new Set(modifiers);
+  const orderedModifiers = includeMod ? MODIFIER_ORDER_WITH_MOD : MODIFIER_ORDER;
+  const normalizedModifiers = orderedModifiers.filter((token) => modifierSet.has(token));
+  return [...normalizedModifiers, key].join("+");
+}
+
+function normalizeKeyToken(token: string): string | null {
+  const lower = token.trim().toLowerCase();
+  if (!lower) {
+    return null;
+  }
+
+  if (lower === "?") {
+    return "/";
+  }
+
+  const synonym = KEY_SYNONYMS.get(lower);
+  if (synonym) {
+    return synonym;
+  }
+
+  if (SPECIAL_KEYS.has(lower)) {
+    return lower;
+  }
+
+  if (/^f([1-9]|1[0-2])$/.test(lower)) {
+    return lower;
+  }
+
+  if (lower.length === 1) {
+    return lower;
+  }
+
+  return null;
+}
+
+function keyTokenFromEvent(event: ShortcutEvent): string | null {
+  if (event.code.startsWith("Key") && event.code.length === 4) {
+    return event.code.slice(3).toLowerCase();
+  }
+  if (event.code.startsWith("Digit") && event.code.length === 6) {
+    return event.code.slice(5);
+  }
+  if (event.code.startsWith("Numpad") && event.code.length === 7) {
+    const key = event.code.slice(6);
+    if (/^[0-9]$/.test(key)) {
+      return key;
+    }
+  }
+  if (CODE_TO_KEY.has(event.code)) {
+    return CODE_TO_KEY.get(event.code) ?? null;
+  }
+
+  const fallback = normalizeKeyToken(event.key);
+  if (!fallback) {
+    return null;
+  }
+  if (MODIFIER_KEYS.has(fallback)) {
+    return null;
+  }
+  return fallback;
+}
+
+export function normalizeShortcut(raw: string): string | null {
+  const tokens = raw
+    .split("+")
+    .map((token) => token.trim())
+    .filter(Boolean);
+  if (tokens.length === 0) {
+    return null;
+  }
+
+  const modifiers = new Set<string>();
+  let key: string | null = null;
+
+  for (const token of tokens) {
+    const lower = token.toLowerCase();
+    const modifier = SHORTCUT_MODIFIER_ALIASES.get(lower);
+    if (modifier) {
+      modifiers.add(modifier);
+      continue;
+    }
+
+    const normalizedKey = normalizeKeyToken(token);
+    if (!normalizedKey) {
+      return null;
+    }
+    if (key !== null) {
+      return null;
+    }
+    key = normalizedKey;
+
+    if (lower === "?") {
+      modifiers.add("shift");
+    }
+  }
+
+  if (!key) {
+    return null;
+  }
+  return canonicalizeShortcut(modifiers, key, true);
+}
+
+export function resolveShortcutForPlatform(
+  shortcut: string,
+  platform: ShortcutPlatform,
+): string | null {
+  const normalized = normalizeShortcut(shortcut);
+  if (!normalized) {
+    return null;
+  }
+  const parts = normalized.split("+");
+  const key = parts.pop();
+  if (!key) {
+    return null;
+  }
+  const modifiers = new Set(
+    parts.map((token) => {
+      if (token === "mod") {
+        return platform === "mac" ? "meta" : "ctrl";
+      }
+      return token;
+    }),
+  );
+  return canonicalizeShortcut(modifiers, key, false);
+}
+
+export function keyboardEventToShortcut(event: ShortcutEvent): string | null {
+  const key = keyTokenFromEvent(event);
+  if (!key) {
+    return null;
+  }
+
+  const modifiers = new Set<string>();
+  if (event.ctrlKey) {
+    modifiers.add("ctrl");
+  }
+  if (event.metaKey) {
+    modifiers.add("meta");
+  }
+  if (event.altKey) {
+    modifiers.add("alt");
+  }
+  if (event.shiftKey) {
+    modifiers.add("shift");
+  }
+
+  return canonicalizeShortcut(modifiers, key, false);
+}
+
+export function shortcutMatchesEvent(
+  shortcut: string,
+  event: ShortcutEvent,
+  platform: ShortcutPlatform,
+): boolean {
+  const resolvedShortcut = resolveShortcutForPlatform(shortcut, platform);
+  if (!resolvedShortcut) {
+    return false;
+  }
+  return keyboardEventToShortcut(event) === resolvedShortcut;
+}
+
+function displayKeyToken(key: string, platform: ShortcutPlatform): string {
+  if (platform === "mac") {
+    const macLabel = DISPLAY_KEY_LABEL_MAC.get(key);
+    if (macLabel) {
+      return macLabel;
+    }
+  }
+  const commonLabel = DISPLAY_KEY_LABEL.get(key);
+  if (commonLabel) {
+    return commonLabel;
+  }
+  if (key.length === 1) {
+    return key.toUpperCase();
+  }
+  return key.toUpperCase();
+}
+
+export function formatShortcut(shortcut: string, platform: ShortcutPlatform): string {
+  const resolved = resolveShortcutForPlatform(shortcut, platform);
+  if (!resolved) {
+    return "";
+  }
+  const tokens = resolved.split("+");
+  const key = tokens.pop();
+  if (!key) {
+    return "";
+  }
+
+  if (platform === "mac") {
+    const symbols = [
+      tokens.includes("ctrl") ? "⌃" : "",
+      tokens.includes("meta") ? "⌘" : "",
+      tokens.includes("alt") ? "⌥" : "",
+      tokens.includes("shift") ? "⇧" : "",
+    ]
+      .filter(Boolean)
+      .join("");
+    return `${symbols}${displayKeyToken(key, platform)}`;
+  }
+
+  const names = [
+    tokens.includes("ctrl") ? "Ctrl" : "",
+    tokens.includes("meta") ? "Meta" : "",
+    tokens.includes("alt") ? "Alt" : "",
+    tokens.includes("shift") ? "Shift" : "",
+  ].filter(Boolean);
+  names.push(displayKeyToken(key, platform));
+  return names.join("+");
+}
+
+export function filterCommandIds(entries: CommandSearchEntry[], query: string): string[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return entries.map((entry) => entry.id);
+  }
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+
+  return entries
+    .filter((entry) => {
+      const searchCorpus = [
+        entry.label,
+        entry.description ?? "",
+        ...(entry.keywords ?? []),
+        entry.id,
+      ]
+        .join(" ")
+        .toLowerCase();
+      return tokens.every((token) => searchCorpus.includes(token));
+    })
+    .map((entry) => entry.id);
+}
+
+export function pushRecentCommand(history: string[], commandId: string, limit = 8): string[] {
+  const maxItems = Math.max(1, limit);
+  const deduped = [commandId, ...history.filter((value) => value !== commandId)];
+  return deduped.slice(0, maxItems);
+}
+
+export function isEditableEventTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  return Boolean(target.closest("input, textarea, select, [contenteditable='true']"));
+}


### PR DESCRIPTION
## Summary\n- add global command palette with search, recent command history, and entity jump commands\n- add shortcut manager with default keymap, local override support, and shortcut help/rebind UI\n- add command shortcut utility module with unit tests and update README ops UX checklist\n\n## Testing\n- pnpm lint\n- pnpm test\n- pnpm ci:local\n\nCloses #18