### PR TITLE
feat: run comparison panel with saved A/B pairs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1700,7 +1700,7 @@ body {
 .detail-diff-grid {
   margin-top: 10px;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 8px;
 }
 
@@ -1725,12 +1725,140 @@ body {
   font-size: 0.9rem;
 }
 
+.detail-diff-grid small {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.62rem;
+  color: #8dc2d6;
+}
+
 .detail-diff-worse {
   color: #ffc9c9;
 }
 
 .detail-diff-better {
   color: #c9ffd8;
+}
+
+.detail-diff-controls {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  align-items: end;
+}
+
+.detail-diff-field {
+  display: grid;
+  gap: 4px;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  color: #8ec7d8;
+  text-transform: uppercase;
+}
+
+.detail-diff-field select {
+  border-radius: 8px;
+  border: 1px solid rgba(144, 221, 255, 0.34);
+  background: rgba(6, 32, 46, 0.92);
+  color: #dcf6ff;
+  font-size: 0.72rem;
+  padding: 6px 8px;
+}
+
+.detail-diff-actions {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  gap: 6px;
+}
+
+.detail-diff-saved {
+  margin-top: 12px;
+  border: 1px solid rgba(136, 219, 255, 0.22);
+  border-radius: 10px;
+  background: rgba(7, 24, 35, 0.85);
+  padding: 8px;
+}
+
+.detail-diff-saved h4 {
+  margin: 0;
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  color: #bfefff;
+  text-transform: uppercase;
+}
+
+.detail-diff-saved ol {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.detail-diff-saved li {
+  border: 1px solid rgba(136, 219, 255, 0.2);
+  border-radius: 9px;
+  padding: 6px;
+  display: grid;
+  gap: 5px;
+  background: rgba(7, 24, 36, 0.7);
+}
+
+.detail-diff-saved li.is-active {
+  border-color: rgba(173, 236, 255, 0.58);
+}
+
+.detail-diff-saved li span {
+  font-size: 0.72rem;
+  color: #d5f4ff;
+}
+
+.detail-diff-saved li small {
+  font-size: 0.62rem;
+  color: #8ec7d8;
+}
+
+.detail-diff-columns,
+.detail-diff-major-events {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.detail-diff-column {
+  border: 1px solid rgba(139, 223, 255, 0.28);
+  border-radius: 8px;
+  padding: 7px 8px;
+  background: rgba(7, 24, 36, 0.72);
+}
+
+.detail-diff-column h4 {
+  margin: 0;
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #8ec7d8;
+}
+
+.detail-diff-column p {
+  margin: 6px 0 0;
+  font-size: 0.71rem;
+  line-height: 1.4;
+  color: #d4f3ff;
+}
+
+.detail-diff-column ol {
+  margin: 8px 0 0;
+  padding-left: 16px;
+  display: grid;
+  gap: 4px;
+}
+
+.detail-diff-column li {
+  font-size: 0.69rem;
+  line-height: 1.35;
+  color: #d5f3ff;
 }
 
 .diagnostic-strip {
@@ -2520,6 +2648,15 @@ body {
   }
 
   .detail-diff-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .detail-diff-controls {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .detail-diff-columns,
+  .detail-diff-major-events {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/src/lib/run-comparison-store.test.ts
+++ b/src/lib/run-comparison-store.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSavedRunComparisons,
+  removeSavedRunComparison,
+  upsertSavedRunComparison,
+  type SavedRunComparison,
+} from "./run-comparison-store";
+
+function makeSaved(partial?: Partial<SavedRunComparison>): SavedRunComparison {
+  return {
+    id: partial?.id ?? "cmp-1",
+    entityId: partial?.entityId ?? "agent:main",
+    baselineRunId: partial?.baselineRunId ?? "run-ok",
+    candidateRunId: partial?.candidateRunId ?? "run-error",
+    createdAt: partial?.createdAt ?? 1000,
+  };
+}
+
+describe("run comparison store", () => {
+  it("parses and sorts saved comparisons by latest first", () => {
+    const parsed = parseSavedRunComparisons(
+      JSON.stringify([
+        makeSaved({ id: "cmp-1", createdAt: 1000 }),
+        makeSaved({ id: "cmp-2", createdAt: 1200 }),
+      ]),
+    );
+    expect(parsed.map((item) => item.id)).toEqual(["cmp-2", "cmp-1"]);
+  });
+
+  it("ignores invalid records while parsing", () => {
+    const parsed = parseSavedRunComparisons(
+      JSON.stringify([
+        makeSaved({ id: "cmp-1" }),
+        { foo: "bar" },
+        { id: "cmp-2", entityId: "agent:main", baselineRunId: "a", candidateRunId: "b" },
+      ]),
+    );
+    expect(parsed.map((item) => item.id)).toEqual(["cmp-1"]);
+  });
+
+  it("upserts and deduplicates same entity/run pair", () => {
+    const before = [
+      makeSaved({ id: "cmp-1", createdAt: 1000 }),
+      makeSaved({ id: "cmp-2", createdAt: 1100, baselineRunId: "run-ok-2", candidateRunId: "run-error-2" }),
+    ];
+    const next = upsertSavedRunComparison(
+      before,
+      makeSaved({ id: "cmp-3", createdAt: 1300, baselineRunId: "run-ok", candidateRunId: "run-error" }),
+    );
+    expect(next).toHaveLength(2);
+    expect(next.map((item) => item.id)).toEqual(["cmp-3", "cmp-2"]);
+  });
+
+  it("removes a saved comparison by id", () => {
+    const next = removeSavedRunComparison(
+      [makeSaved({ id: "cmp-1" }), makeSaved({ id: "cmp-2", createdAt: 1200 })],
+      "cmp-2",
+    );
+    expect(next.map((item) => item.id)).toEqual(["cmp-1"]);
+  });
+});

--- a/src/lib/run-comparison-store.ts
+++ b/src/lib/run-comparison-store.ts
@@ -1,0 +1,104 @@
+export const RUN_COMPARISON_STORAGE_KEY = "openclawoffice.run-comparisons.v1";
+const MAX_SAVED_COMPARISONS = 20;
+
+export type SavedRunComparison = {
+  id: string;
+  entityId: string;
+  baselineRunId: string;
+  candidateRunId: string;
+  createdAt: number;
+};
+
+function normalizeSavedRunComparison(candidate: unknown): SavedRunComparison | null {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return null;
+  }
+  const record = candidate as Record<string, unknown>;
+  if (
+    typeof record.id !== "string" ||
+    typeof record.entityId !== "string" ||
+    typeof record.baselineRunId !== "string" ||
+    typeof record.candidateRunId !== "string" ||
+    typeof record.createdAt !== "number"
+  ) {
+    return null;
+  }
+  if (!record.id || !record.entityId || !record.baselineRunId || !record.candidateRunId) {
+    return null;
+  }
+  return {
+    id: record.id,
+    entityId: record.entityId,
+    baselineRunId: record.baselineRunId,
+    candidateRunId: record.candidateRunId,
+    createdAt: record.createdAt,
+  };
+}
+
+export function parseSavedRunComparisons(raw: string | null): SavedRunComparison[] {
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((item) => normalizeSavedRunComparison(item))
+      .filter((item): item is SavedRunComparison => item !== null)
+      .sort((left, right) => right.createdAt - left.createdAt);
+  } catch {
+    return [];
+  }
+}
+
+function hasBrowserStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function loadSavedRunComparisons(): SavedRunComparison[] {
+  if (!hasBrowserStorage()) {
+    return [];
+  }
+  try {
+    return parseSavedRunComparisons(window.localStorage.getItem(RUN_COMPARISON_STORAGE_KEY));
+  } catch {
+    return [];
+  }
+}
+
+export function persistSavedRunComparisons(saved: SavedRunComparison[]) {
+  if (!hasBrowserStorage()) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(RUN_COMPARISON_STORAGE_KEY, JSON.stringify(saved));
+  } catch {
+    // Ignore localStorage persistence errors in restricted browser modes.
+  }
+}
+
+export function upsertSavedRunComparison(
+  existing: SavedRunComparison[],
+  candidate: SavedRunComparison,
+): SavedRunComparison[] {
+  const withoutDuplicate = existing.filter(
+    (item) =>
+      !(
+        item.entityId === candidate.entityId &&
+        item.baselineRunId === candidate.baselineRunId &&
+        item.candidateRunId === candidate.candidateRunId
+      ),
+  );
+  return [candidate, ...withoutDuplicate]
+    .sort((left, right) => right.createdAt - left.createdAt)
+    .slice(0, MAX_SAVED_COMPARISONS);
+}
+
+export function removeSavedRunComparison(
+  existing: SavedRunComparison[],
+  id: string,
+): SavedRunComparison[] {
+  return existing.filter((item) => item.id !== id);
+}


### PR DESCRIPTION
## Summary\n- implement run comparison workflow with explicit run A/B selection in the detail panel Diff tab\n- expand comparison KPIs with event density and error point, plus task and major event diffs\n- add local saved comparison history (save/open/delete) per entity with resilient localStorage parsing\n\n## Testing\n- pnpm ci:local\n\nCloses #25