### PR TITLE
feat: add throughput dashboard (latency/concurrency/error)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -127,6 +127,356 @@ body {
   gap: 10px;
 }
 
+.throughput-dashboard {
+  border: 1px solid rgba(150, 229, 255, 0.3);
+  border-radius: 16px;
+  background: rgba(8, 30, 43, 0.78);
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.throughput-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.throughput-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.03em;
+}
+
+.throughput-header p {
+  margin: 4px 0 0;
+  color: #9cd4e8;
+  font-size: 0.72rem;
+}
+
+.throughput-controls {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.throughput-window-toggle {
+  border: 1px solid rgba(148, 226, 255, 0.36);
+  border-radius: 8px;
+  background: rgba(9, 39, 55, 0.88);
+  color: #cdefff;
+  font-size: 0.72rem;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.throughput-window-toggle.is-active {
+  border-color: rgba(135, 255, 196, 0.56);
+  color: #a8ffdc;
+}
+
+.throughput-window-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.throughput-window-card {
+  border: 1px solid rgba(146, 225, 255, 0.28);
+  border-radius: 10px;
+  background: rgba(7, 36, 52, 0.72);
+  padding: 8px;
+  display: grid;
+  gap: 2px;
+  color: #b8e5f3;
+  font-size: 0.68rem;
+}
+
+.throughput-window-card strong {
+  color: #e5fbff;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.throughput-window-card.is-selected {
+  border-color: rgba(140, 255, 200, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(112, 236, 184, 0.3);
+}
+
+.throughput-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.throughput-kpi-card {
+  border: 1px solid rgba(150, 228, 255, 0.28);
+  border-radius: 10px;
+  background: rgba(8, 34, 49, 0.72);
+  padding: 8px 10px;
+  display: grid;
+  gap: 3px;
+}
+
+.throughput-kpi-card span {
+  color: #a6d9ea;
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.throughput-kpi-card strong {
+  font-size: 1.04rem;
+}
+
+.throughput-kpi-card small {
+  color: #8ec8dc;
+  font-size: 0.64rem;
+}
+
+.throughput-main-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+  gap: 10px;
+}
+
+.throughput-chart-panel,
+.throughput-agent-panel,
+.throughput-outlier-panel {
+  border: 1px solid rgba(145, 224, 255, 0.26);
+  border-radius: 12px;
+  background: rgba(6, 31, 45, 0.72);
+  padding: 10px;
+}
+
+.throughput-chart-panel header,
+.throughput-agent-panel header,
+.throughput-outlier-panel header {
+  margin-bottom: 6px;
+}
+
+.throughput-chart-panel h3,
+.throughput-agent-panel h3,
+.throughput-outlier-panel h3 {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.throughput-chart-panel p,
+.throughput-agent-panel p,
+.throughput-outlier-panel p {
+  margin: 3px 0 0;
+  color: #98cede;
+  font-size: 0.67rem;
+}
+
+.throughput-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 0.63rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.throughput-chart-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #a7d9ea;
+}
+
+.throughput-chart-legend span::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: rgba(177, 230, 255, 0.4);
+}
+
+.throughput-chart-legend .started::before {
+  background: rgba(146, 216, 255, 0.72);
+}
+
+.throughput-chart-legend .completed::before {
+  background: rgba(127, 255, 204, 0.76);
+}
+
+.throughput-chart-legend .error::before {
+  background: rgba(255, 148, 148, 0.78);
+}
+
+.throughput-chart-legend .concurrency::before {
+  background: rgba(255, 199, 118, 0.75);
+}
+
+.throughput-chart-grid {
+  border: 1px solid rgba(147, 225, 255, 0.22);
+  border-radius: 10px;
+  background: rgba(6, 30, 44, 0.88);
+  padding: 8px;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 6px;
+  min-height: 180px;
+}
+
+.throughput-chart-bucket {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: 4px;
+  align-items: end;
+}
+
+.throughput-concurrency-strip {
+  grid-row: 1;
+  grid-column: 1;
+  border-radius: 8px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 216, 153, 0.55),
+    rgba(255, 192, 122, 0.08)
+  );
+}
+
+.throughput-chart-bars {
+  grid-row: 1;
+  grid-column: 1;
+  min-height: 120px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 226, 255, 0.16);
+  background: rgba(7, 30, 44, 0.74);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 3px;
+  padding: 6px 3px;
+  z-index: 1;
+}
+
+.throughput-chart-bar {
+  width: 6px;
+  border-radius: 3px 3px 0 0;
+}
+
+.throughput-chart-bar.started {
+  background: rgba(147, 216, 255, 0.88);
+}
+
+.throughput-chart-bar.completed {
+  background: rgba(134, 255, 208, 0.9);
+}
+
+.throughput-chart-bar.error {
+  background: rgba(255, 148, 148, 0.92);
+}
+
+.throughput-chart-bucket small {
+  font-size: 0.56rem;
+  color: #8fc8dd;
+  text-align: center;
+}
+
+.throughput-agent-actions {
+  margin-bottom: 8px;
+}
+
+.throughput-agent-actions button,
+.throughput-agent-table button {
+  border: 1px solid rgba(148, 226, 255, 0.36);
+  border-radius: 7px;
+  background: rgba(9, 39, 55, 0.88);
+  color: #d3f2ff;
+  font-size: 0.66rem;
+  padding: 5px 8px;
+  cursor: pointer;
+}
+
+.throughput-agent-actions button.is-active {
+  border-color: rgba(135, 255, 196, 0.58);
+  color: #9dffd8;
+}
+
+.throughput-agent-table-wrap {
+  overflow: auto;
+}
+
+.throughput-agent-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.67rem;
+}
+
+.throughput-agent-table th,
+.throughput-agent-table td {
+  padding: 6px 4px;
+  border-bottom: 1px solid rgba(145, 223, 255, 0.12);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.throughput-agent-table thead th {
+  color: #8dc7db;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.62rem;
+}
+
+.throughput-agent-table tbody tr.is-selected {
+  background: rgba(88, 203, 164, 0.14);
+}
+
+.throughput-agent-empty {
+  text-align: center;
+  color: #95cada;
+}
+
+.throughput-outlier-panel {
+  display: grid;
+  gap: 8px;
+}
+
+.throughput-outlier-empty {
+  margin: 0;
+  font-size: 0.68rem;
+  color: #9acddf;
+}
+
+.throughput-outlier-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.throughput-outlier-item {
+  border: 1px solid rgba(148, 225, 255, 0.26);
+  border-radius: 9px;
+  padding: 7px 8px;
+  display: grid;
+  gap: 2px;
+  font-size: 0.67rem;
+  color: #ccefff;
+}
+
+.throughput-outlier-item strong {
+  font-size: 0.72rem;
+}
+
+.throughput-outlier-item.high {
+  border-color: rgba(255, 164, 164, 0.52);
+  background: rgba(71, 31, 36, 0.36);
+}
+
+.throughput-outlier-item.medium {
+  border-color: rgba(255, 215, 136, 0.46);
+  background: rgba(64, 47, 22, 0.34);
+}
+
 .ops-toolbar {
   border: 1px solid rgba(149, 227, 255, 0.28);
   border-radius: 14px;
@@ -2540,6 +2890,18 @@ body {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
+  .throughput-window-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .throughput-kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .throughput-main-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .ops-toolbar {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -2638,6 +3000,23 @@ body {
 
   .stats-bar {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .throughput-header {
+    flex-direction: column;
+  }
+
+  .throughput-window-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .throughput-kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .throughput-chart-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    row-gap: 8px;
   }
 
   .ops-toolbar {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { CommandPalette, type CommandPaletteEntry } from "./components/CommandPa
 import { EntityDetailPanel } from "./components/EntityDetailPanel";
 import { EventRail } from "./components/EventRail";
 import { OfficeStage } from "./components/OfficeStage";
+import { ThroughputDashboard } from "./components/ThroughputDashboard";
 import { useOfficeStream } from "./hooks/useOfficeStream";
 import {
   ALERT_RULE_LABELS,
@@ -1269,6 +1270,8 @@ function App() {
         <StatCard label="Errors" value={failed} accent="#ff8686" />
         <StatCard label="Events" value={snapshot.events.length} accent="#96b4ff" />
       </section>
+
+      <ThroughputDashboard snapshot={snapshot} />
 
       <section className="ops-toolbar">
         <label className="ops-field ops-search">

--- a/src/components/ThroughputDashboard.tsx
+++ b/src/components/ThroughputDashboard.tsx
@@ -1,0 +1,315 @@
+import { useMemo, useState } from "react";
+import {
+  THROUGHPUT_WINDOWS,
+  buildAgentThroughputBreakdown,
+  buildThroughputOutliers,
+  buildThroughputSeries,
+  buildThroughputWindowMetrics,
+  type ThroughputWindow,
+} from "../lib/throughput-dashboard";
+import type { OfficeSnapshot } from "../types/office";
+
+type Props = {
+  snapshot: OfficeSnapshot;
+};
+
+const WINDOW_LABELS: Record<ThroughputWindow, string> = {
+  "5m": "5m",
+  "1h": "1h",
+  "24h": "24h",
+};
+
+function formatPercent(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatDuration(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+  if (value < 1000) {
+    return `${value}ms`;
+  }
+  if (value < 60_000) {
+    return `${(value / 1000).toFixed(1)}s`;
+  }
+  return `${(value / 60_000).toFixed(1)}m`;
+}
+
+function ratioToPercentHeight(value: number, max: number): string {
+  if (value <= 0) {
+    return "0%";
+  }
+  if (max <= 0) {
+    return "0%";
+  }
+  return `${Math.max(6, Math.round((value / max) * 100))}%`;
+}
+
+export function ThroughputDashboard({ snapshot }: Props) {
+  const [selectedWindow, setSelectedWindow] = useState<ThroughputWindow>("1h");
+  const [drillAgentId, setDrillAgentId] = useState<string | null>(null);
+
+  const agentBreakdown = useMemo(
+    () => buildAgentThroughputBreakdown(snapshot, selectedWindow),
+    [selectedWindow, snapshot],
+  );
+
+  const effectiveDrillAgentId =
+    drillAgentId && agentBreakdown.some((agent) => agent.agentId === drillAgentId)
+      ? drillAgentId
+      : null;
+
+  const windowMetrics = useMemo(
+    () =>
+      buildThroughputWindowMetrics(snapshot, {
+        now: snapshot.generatedAt,
+        agentId: effectiveDrillAgentId ?? undefined,
+      }),
+    [effectiveDrillAgentId, snapshot],
+  );
+
+  const selectedMetrics = windowMetrics[selectedWindow];
+
+  const series = useMemo(
+    () =>
+      buildThroughputSeries(snapshot, selectedWindow, {
+        now: snapshot.generatedAt,
+        agentId: effectiveDrillAgentId ?? undefined,
+      }),
+    [effectiveDrillAgentId, selectedWindow, snapshot],
+  );
+
+  const outliers = useMemo(
+    () =>
+      buildThroughputOutliers(snapshot, selectedWindow, {
+        now: snapshot.generatedAt,
+        agentId: effectiveDrillAgentId ?? undefined,
+      }),
+    [effectiveDrillAgentId, selectedWindow, snapshot],
+  );
+
+  const maxRunCount = Math.max(
+    1,
+    ...series.map((bucket) => Math.max(bucket.startedRuns, bucket.completedRuns, bucket.errorRuns)),
+  );
+  const maxConcurrency = Math.max(1, ...series.map((bucket) => bucket.maxConcurrency));
+
+  return (
+    <section className="throughput-dashboard" aria-label="Throughput dashboard">
+      <header className="throughput-header">
+        <div>
+          <h2>Throughput Dashboard</h2>
+          <p>
+            Compare 5m/1h/24h KPIs, drill into agent metrics, and surface latency/error hotspots.
+          </p>
+        </div>
+
+        <div className="throughput-controls" role="tablist" aria-label="Throughput windows">
+          {THROUGHPUT_WINDOWS.map((window) => (
+            <button
+              key={window}
+              type="button"
+              role="tab"
+              aria-selected={window === selectedWindow}
+              className={`throughput-window-toggle${window === selectedWindow ? " is-active" : ""}`}
+              onClick={() => {
+                setSelectedWindow(window);
+              }}
+            >
+              {WINDOW_LABELS[window]}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="throughput-window-grid">
+        {THROUGHPUT_WINDOWS.map((window) => {
+          const metrics = windowMetrics[window];
+          return (
+            <article
+              key={window}
+              className={`throughput-window-card${window === selectedWindow ? " is-selected" : ""}`}
+            >
+              <strong>{WINDOW_LABELS[window]}</strong>
+              <span>completion {formatPercent(metrics.completionRate)}</span>
+              <span>avg {formatDuration(metrics.avgDurationMs)}</span>
+              <span>concurrency {metrics.activeConcurrency}</span>
+              <span>error {formatPercent(metrics.errorRatio)}</span>
+            </article>
+          );
+        })}
+      </div>
+
+      <div className="throughput-kpi-grid">
+        <article className="throughput-kpi-card">
+          <span>Run Completion Rate</span>
+          <strong>{formatPercent(selectedMetrics.completionRate)}</strong>
+          <small>
+            {selectedMetrics.completedRuns}/{selectedMetrics.startedRuns} runs completed
+          </small>
+        </article>
+        <article className="throughput-kpi-card">
+          <span>Avg Duration</span>
+          <strong>{formatDuration(selectedMetrics.avgDurationMs)}</strong>
+          <small>{selectedWindow} window average</small>
+        </article>
+        <article className="throughput-kpi-card">
+          <span>Active Concurrency</span>
+          <strong>{selectedMetrics.activeConcurrency}</strong>
+          <small>peak concurrent runs in window</small>
+        </article>
+        <article className="throughput-kpi-card">
+          <span>Error Ratio</span>
+          <strong>{formatPercent(selectedMetrics.errorRatio)}</strong>
+          <small>{selectedMetrics.eventsInWindow} events observed</small>
+        </article>
+      </div>
+
+      <div className="throughput-main-grid">
+        <section className="throughput-chart-panel">
+          <header>
+            <h3>
+              Window Trend {effectiveDrillAgentId ? `(agent: ${effectiveDrillAgentId})` : "(all agents)"}
+            </h3>
+            <p>Started/completed/error buckets with concurrency heat.</p>
+          </header>
+
+          <div className="throughput-chart-legend">
+            <span className="started">Started</span>
+            <span className="completed">Completed</span>
+            <span className="error">Error</span>
+            <span className="concurrency">Concurrency</span>
+          </div>
+
+          <div className="throughput-chart-grid" role="img" aria-label="Throughput bucket chart">
+            {series.map((bucket) => {
+              const startedHeight = ratioToPercentHeight(bucket.startedRuns, maxRunCount);
+              const completedHeight = ratioToPercentHeight(bucket.completedRuns, maxRunCount);
+              const errorHeight = ratioToPercentHeight(bucket.errorRuns, maxRunCount);
+              const concurrencyOpacity = 0.16 + (bucket.maxConcurrency / maxConcurrency) * 0.72;
+              return (
+                <article key={bucket.index} className="throughput-chart-bucket">
+                  <span className="throughput-concurrency-strip" style={{ opacity: concurrencyOpacity }} />
+                  <div className="throughput-chart-bars">
+                    <span
+                      className="throughput-chart-bar started"
+                      style={{ height: startedHeight }}
+                      title={`Started ${bucket.startedRuns}`}
+                    />
+                    <span
+                      className="throughput-chart-bar completed"
+                      style={{ height: completedHeight }}
+                      title={`Completed ${bucket.completedRuns}`}
+                    />
+                    <span
+                      className="throughput-chart-bar error"
+                      style={{ height: errorHeight }}
+                      title={`Error ${bucket.errorRuns}`}
+                    />
+                  </div>
+                  <small>{bucket.label}</small>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="throughput-agent-panel">
+          <header>
+            <h3>Agent Drill-down</h3>
+            <p>Ranked by started runs in {selectedWindow}.</p>
+          </header>
+
+          <div className="throughput-agent-actions">
+            <button
+              type="button"
+              onClick={() => {
+                setDrillAgentId(null);
+              }}
+              className={effectiveDrillAgentId === null ? "is-active" : ""}
+            >
+              Show all
+            </button>
+          </div>
+
+          <div className="throughput-agent-table-wrap">
+            <table className="throughput-agent-table">
+              <thead>
+                <tr>
+                  <th>Agent</th>
+                  <th>Runs</th>
+                  <th>Completion</th>
+                  <th>Avg</th>
+                  <th>Error</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {agentBreakdown.slice(0, 10).map((agent) => (
+                  <tr
+                    key={agent.agentId}
+                    className={effectiveDrillAgentId === agent.agentId ? "is-selected" : ""}
+                  >
+                    <td>{agent.agentId}</td>
+                    <td>
+                      {agent.completedRuns}/{agent.startedRuns}
+                    </td>
+                    <td>{formatPercent(agent.completionRate)}</td>
+                    <td>{formatDuration(agent.avgDurationMs)}</td>
+                    <td>{formatPercent(agent.errorRatio)}</td>
+                    <td>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setDrillAgentId((prev) =>
+                            prev === agent.agentId ? null : agent.agentId,
+                          );
+                        }}
+                      >
+                        {effectiveDrillAgentId === agent.agentId ? "Clear" : "Focus"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+                {agentBreakdown.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="throughput-agent-empty">
+                      No agent runs in this window.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      <section className="throughput-outlier-panel">
+        <header>
+          <h3>Anomaly Highlights</h3>
+          <p>Outlier candidates based on latency, error ratio, and completion drop.</p>
+        </header>
+
+        {outliers.length === 0 ? (
+          <p className="throughput-outlier-empty">No notable outliers for the current scope.</p>
+        ) : (
+          <ul className="throughput-outlier-list">
+            {outliers.map((outlier) => (
+              <li
+                key={outlier.id}
+                className={`throughput-outlier-item ${outlier.severity}`}
+              >
+                <strong>{outlier.title}</strong>
+                <span>{outlier.detail}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/src/lib/throughput-dashboard.test.ts
+++ b/src/lib/throughput-dashboard.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import type { OfficeRun, OfficeSnapshot } from "../types/office";
+import { buildRunGraph } from "./run-graph";
+import {
+  buildAgentThroughputBreakdown,
+  buildThroughputOutliers,
+  buildThroughputSeries,
+  buildThroughputWindowMetrics,
+} from "./throughput-dashboard";
+
+const NOW = 1_700_000_000_000;
+
+function makeRun(input: {
+  runId: string;
+  agentId: string;
+  status: OfficeRun["status"];
+  startedOffsetMs: number;
+  endedOffsetMs?: number;
+}): OfficeRun {
+  const startedAt = NOW + input.startedOffsetMs;
+  const endedAt =
+    typeof input.endedOffsetMs === "number" ? NOW + input.endedOffsetMs : undefined;
+
+  return {
+    runId: input.runId,
+    childSessionKey: `agent:${input.agentId}:session:${input.runId}`,
+    requesterSessionKey: `agent:root:session:${input.runId}`,
+    childAgentId: input.agentId,
+    parentAgentId: "root",
+    status: input.status,
+    task: `Task for ${input.runId}`,
+    cleanup: "keep",
+    createdAt: startedAt - 1_000,
+    startedAt,
+    endedAt,
+    cleanupCompletedAt: endedAt ? endedAt + 500 : undefined,
+  };
+}
+
+function makeSnapshot(runs: OfficeRun[]): OfficeSnapshot {
+  const events = runs.flatMap((run) => {
+    const spawnAt = run.createdAt;
+    const startAt = run.startedAt ?? run.createdAt;
+    const endAt = run.endedAt;
+
+    const base = [
+      {
+        id: `${run.runId}:spawn`,
+        type: "spawn" as const,
+        runId: run.runId,
+        at: spawnAt,
+        agentId: run.childAgentId,
+        parentAgentId: run.parentAgentId,
+        text: `spawn ${run.runId}`,
+      },
+      {
+        id: `${run.runId}:start`,
+        type: "start" as const,
+        runId: run.runId,
+        at: startAt,
+        agentId: run.childAgentId,
+        parentAgentId: run.parentAgentId,
+        text: `start ${run.runId}`,
+      },
+    ];
+
+    if (!endAt) {
+      return base;
+    }
+
+    return [
+      ...base,
+      {
+        id: `${run.runId}:${run.status === "error" ? "error" : "end"}`,
+        type: run.status === "error" ? ("error" as const) : ("end" as const),
+        runId: run.runId,
+        at: endAt,
+        agentId: run.childAgentId,
+        parentAgentId: run.parentAgentId,
+        text: `${run.status} ${run.runId}`,
+      },
+    ];
+  });
+
+  const agents = [...new Set(runs.map((run) => run.childAgentId))];
+
+  return {
+    generatedAt: NOW,
+    source: {
+      stateDir: "/tmp/openclaw",
+      live: true,
+    },
+    diagnostics: [],
+    entities: [
+      ...agents.map((agentId) => ({
+        id: `agent:${agentId}`,
+        kind: "agent" as const,
+        label: agentId,
+        agentId,
+        status: "active" as const,
+        sessions: 1,
+        activeSubagents: runs.filter(
+          (run) => run.childAgentId === agentId && run.status === "active",
+        ).length,
+      })),
+      ...runs.map((run) => ({
+        id: `subagent:${run.runId}`,
+        kind: "subagent" as const,
+        label: run.runId,
+        agentId: run.childAgentId,
+        parentAgentId: run.parentAgentId,
+        runId: run.runId,
+        status: run.status,
+        sessions: 1,
+        activeSubagents: 0,
+      })),
+    ],
+    runs,
+    events,
+    runGraph: buildRunGraph(runs),
+  };
+}
+
+describe("throughput dashboard metrics", () => {
+  it("computes core KPI windows (5m / 1h / 24h)", () => {
+    const snapshot = makeSnapshot([
+      makeRun({ runId: "run-a", agentId: "agent-a", status: "ok", startedOffsetMs: -120_000, endedOffsetMs: -60_000 }),
+      makeRun({ runId: "run-b", agentId: "agent-a", status: "active", startedOffsetMs: -240_000 }),
+      makeRun({ runId: "run-c", agentId: "agent-b", status: "error", startedOffsetMs: -600_000, endedOffsetMs: -480_000 }),
+      makeRun({ runId: "run-d", agentId: "agent-b", status: "ok", startedOffsetMs: -2_400_000, endedOffsetMs: -1_200_000 }),
+      makeRun({ runId: "run-e", agentId: "agent-c", status: "ok", startedOffsetMs: -10_800_000, endedOffsetMs: -7_200_000 }),
+    ]);
+
+    const metrics = buildThroughputWindowMetrics(snapshot, { now: NOW });
+
+    expect(metrics["5m"].startedRuns).toBe(2);
+    expect(metrics["5m"].completedRuns).toBe(1);
+    expect(metrics["5m"].completionRate).toBe(0.5);
+    expect(metrics["5m"].avgDurationMs).toBe(60_000);
+    expect(metrics["5m"].activeConcurrency).toBe(2);
+
+    expect(metrics["1h"].startedRuns).toBe(4);
+    expect(metrics["1h"].completedRuns).toBe(3);
+    expect(metrics["1h"].completionRate).toBe(0.75);
+    expect(metrics["1h"].errorRatio).toBeCloseTo(1 / 3);
+    expect(metrics["1h"].avgDurationMs).toBe(460_000);
+
+    expect(metrics["24h"].startedRuns).toBe(5);
+    expect(metrics["24h"].completedRuns).toBe(4);
+    expect(metrics["24h"].completionRate).toBe(0.8);
+  });
+
+  it("builds bucketed series and preserves started run totals", () => {
+    const snapshot = makeSnapshot([
+      makeRun({ runId: "run-a", agentId: "agent-a", status: "ok", startedOffsetMs: -290_000, endedOffsetMs: -230_000 }),
+      makeRun({ runId: "run-b", agentId: "agent-a", status: "ok", startedOffsetMs: -180_000, endedOffsetMs: -100_000 }),
+      makeRun({ runId: "run-c", agentId: "agent-b", status: "error", startedOffsetMs: -60_000, endedOffsetMs: -15_000 }),
+    ]);
+
+    const series = buildThroughputSeries(snapshot, "5m", {
+      now: NOW,
+      bucketCount: 5,
+    });
+
+    expect(series).toHaveLength(5);
+    expect(series.reduce((sum, bucket) => sum + bucket.startedRuns, 0)).toBe(3);
+    expect(series.some((bucket) => bucket.errorRuns > 0)).toBe(true);
+    expect(Math.max(...series.map((bucket) => bucket.maxConcurrency))).toBeGreaterThan(0);
+  });
+
+  it("supports agent drill-down and slow-run outlier highlighting", () => {
+    const snapshot = makeSnapshot([
+      makeRun({ runId: "run-fast-1", agentId: "agent-a", status: "ok", startedOffsetMs: -3_000_000, endedOffsetMs: -2_940_000 }),
+      makeRun({ runId: "run-fast-2", agentId: "agent-a", status: "ok", startedOffsetMs: -2_800_000, endedOffsetMs: -2_730_000 }),
+      makeRun({ runId: "run-fail-1", agentId: "agent-b", status: "error", startedOffsetMs: -2_700_000, endedOffsetMs: -2_640_000 }),
+      makeRun({ runId: "run-fail-2", agentId: "agent-b", status: "error", startedOffsetMs: -2_500_000, endedOffsetMs: -2_430_000 }),
+      makeRun({ runId: "run-slow", agentId: "agent-c", status: "ok", startedOffsetMs: -3_500_000, endedOffsetMs: -600_000 }),
+    ]);
+
+    const breakdown = buildAgentThroughputBreakdown(snapshot, "1h", { now: NOW });
+    expect(breakdown.map((item) => item.agentId)).toEqual(
+      expect.arrayContaining(["agent-a", "agent-b", "agent-c"]),
+    );
+
+    const focused = buildThroughputWindowMetrics(snapshot, {
+      now: NOW,
+      agentId: "agent-b",
+    });
+    expect(focused["1h"].startedRuns).toBe(2);
+    expect(focused["1h"].errorRatio).toBe(1);
+
+    const outliers = buildThroughputOutliers(snapshot, "1h", { now: NOW });
+    expect(outliers.some((item) => item.id === "slow:run-slow")).toBe(true);
+    expect(outliers.some((item) => item.id === "error:agent-b")).toBe(true);
+  });
+});

--- a/src/lib/throughput-dashboard.ts
+++ b/src/lib/throughput-dashboard.ts
@@ -1,0 +1,453 @@
+import type { OfficeRun, OfficeSnapshot } from "../types/office";
+
+export type ThroughputWindow = "5m" | "1h" | "24h";
+
+export type ThroughputWindowMetrics = {
+  window: ThroughputWindow;
+  startedRuns: number;
+  completedRuns: number;
+  completionRate: number | null;
+  avgDurationMs: number | null;
+  activeConcurrency: number;
+  errorRatio: number | null;
+  eventsInWindow: number;
+  eventsPerMinute: number | null;
+};
+
+export type ThroughputSeriesBucket = {
+  index: number;
+  startAt: number;
+  endAt: number;
+  label: string;
+  startedRuns: number;
+  completedRuns: number;
+  errorRuns: number;
+  maxConcurrency: number;
+};
+
+export type ThroughputAgentMetrics = {
+  agentId: string;
+  startedRuns: number;
+  completedRuns: number;
+  activeRuns: number;
+  completionRate: number | null;
+  avgDurationMs: number | null;
+  errorRatio: number | null;
+  eventCount: number;
+  latestRunAt: number;
+};
+
+export type ThroughputOutlier = {
+  id: string;
+  severity: "high" | "medium";
+  title: string;
+  detail: string;
+  agentId?: string;
+  runId?: string;
+};
+
+export const THROUGHPUT_WINDOWS: ThroughputWindow[] = ["5m", "1h", "24h"];
+
+const WINDOW_MS: Record<ThroughputWindow, number> = {
+  "5m": 5 * 60_000,
+  "1h": 60 * 60_000,
+  "24h": 24 * 60 * 60_000,
+};
+
+type RunStats = {
+  run: OfficeRun;
+  startedAt: number;
+  completedAt: number | null;
+  durationMs: number | null;
+  endForConcurrency: number;
+};
+
+type WindowBounds = {
+  startAt: number;
+  endAt: number;
+};
+
+type DashboardSelectionOptions = {
+  now?: number;
+  agentId?: string;
+};
+
+type ThroughputSeriesOptions = DashboardSelectionOptions & {
+  bucketCount?: number;
+};
+
+function round(value: number, digits = 2): number {
+  const base = 10 ** digits;
+  return Math.round(value * base) / base;
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+function resolveBounds(window: ThroughputWindow, now: number): WindowBounds {
+  return {
+    startAt: now - WINDOW_MS[window],
+    endAt: now,
+  };
+}
+
+function startedAtOf(run: OfficeRun): number {
+  return run.startedAt ?? run.createdAt;
+}
+
+function completedAtOf(run: OfficeRun): number | null {
+  if (run.status === "active") {
+    return null;
+  }
+  const completedAt = run.endedAt ?? run.cleanupCompletedAt;
+  if (typeof completedAt !== "number") {
+    return null;
+  }
+  return completedAt;
+}
+
+function endForConcurrencyOf(run: OfficeRun, now: number): number {
+  if (run.status === "active") {
+    return now;
+  }
+  return run.endedAt ?? run.cleanupCompletedAt ?? now;
+}
+
+function durationOf(startedAt: number, completedAt: number | null): number | null {
+  if (completedAt === null) {
+    return null;
+  }
+  if (completedAt < startedAt) {
+    return null;
+  }
+  return completedAt - startedAt;
+}
+
+function runToStats(run: OfficeRun, now: number): RunStats {
+  const startedAt = startedAtOf(run);
+  const completedAt = completedAtOf(run);
+  return {
+    run,
+    startedAt,
+    completedAt,
+    durationMs: durationOf(startedAt, completedAt),
+    endForConcurrency: endForConcurrencyOf(run, now),
+  };
+}
+
+function withinRange(value: number, bounds: WindowBounds): boolean {
+  return value >= bounds.startAt && value <= bounds.endAt;
+}
+
+function intersectsRange(startAt: number, endAt: number, bounds: WindowBounds): boolean {
+  return endAt >= bounds.startAt && startAt <= bounds.endAt;
+}
+
+function toTimeLabel(at: number, window: ThroughputWindow): string {
+  const date = new Date(at);
+  if (window === "5m") {
+    return date.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  }
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function percentile(values: number[], ratioValue: number): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  const clamped = Math.min(1, Math.max(0, ratioValue));
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.ceil((sorted.length - 1) * clamped);
+  return sorted[index] ?? sorted[sorted.length - 1] ?? null;
+}
+
+function peakConcurrency(runs: RunStats[], bounds: WindowBounds): number {
+  if (runs.length === 0) {
+    return 0;
+  }
+
+  const deltas = new Map<number, number>();
+  for (const run of runs) {
+    if (!intersectsRange(run.startedAt, run.endForConcurrency, bounds)) {
+      continue;
+    }
+    const visibleStart = Math.max(run.startedAt, bounds.startAt);
+    const visibleEnd = Math.min(run.endForConcurrency, bounds.endAt);
+    if (visibleEnd < visibleStart) {
+      continue;
+    }
+
+    deltas.set(visibleStart, (deltas.get(visibleStart) ?? 0) + 1);
+    const releasePoint = visibleEnd + 1;
+    deltas.set(releasePoint, (deltas.get(releasePoint) ?? 0) - 1);
+  }
+
+  let current = 0;
+  let peak = 0;
+  const points = [...deltas.entries()].sort((left, right) => left[0] - right[0]);
+  for (const [, delta] of points) {
+    current += delta;
+    if (current > peak) {
+      peak = current;
+    }
+  }
+  return peak;
+}
+
+function selectRunStats(snapshot: OfficeSnapshot, options: DashboardSelectionOptions): RunStats[] {
+  const now = options.now ?? snapshot.generatedAt;
+  const agentId = options.agentId?.trim() || null;
+  return snapshot.runs
+    .filter((run) => (agentId ? run.childAgentId === agentId : true))
+    .map((run) => runToStats(run, now));
+}
+
+function eventsInWindow(snapshot: OfficeSnapshot, bounds: WindowBounds, agentId?: string): number {
+  const filterAgentId = agentId?.trim() || null;
+  let total = 0;
+  for (const event of snapshot.events) {
+    if (!withinRange(event.at, bounds)) {
+      continue;
+    }
+    if (filterAgentId && event.agentId !== filterAgentId && event.parentAgentId !== filterAgentId) {
+      continue;
+    }
+    total += 1;
+  }
+  return total;
+}
+
+export function buildThroughputWindowMetrics(
+  snapshot: OfficeSnapshot,
+  options: DashboardSelectionOptions = {},
+): Record<ThroughputWindow, ThroughputWindowMetrics> {
+  const now = options.now ?? snapshot.generatedAt;
+  const runStats = selectRunStats(snapshot, options);
+
+  return Object.fromEntries(
+    THROUGHPUT_WINDOWS.map((window) => {
+      const bounds = resolveBounds(window, now);
+      const startedInWindow = runStats.filter((item) => withinRange(item.startedAt, bounds));
+      const completedInWindow = startedInWindow.filter((item) => item.completedAt !== null);
+      const completedDurations = completedInWindow
+        .map((item) => item.durationMs)
+        .filter((value): value is number => typeof value === "number");
+      const errorRuns = completedInWindow.filter((item) => item.run.status === "error").length;
+
+      const eventCount = eventsInWindow(snapshot, bounds, options.agentId);
+      const eventRate = ratio(eventCount, WINDOW_MS[window] / 60_000);
+
+      const metrics: ThroughputWindowMetrics = {
+        window,
+        startedRuns: startedInWindow.length,
+        completedRuns: completedInWindow.length,
+        completionRate: ratio(completedInWindow.length, startedInWindow.length),
+        avgDurationMs:
+          completedDurations.length === 0
+            ? null
+            : round(
+                completedDurations.reduce((sum, value) => sum + value, 0) / completedDurations.length,
+                0,
+              ),
+        activeConcurrency: peakConcurrency(runStats, bounds),
+        errorRatio: ratio(errorRuns, completedInWindow.length),
+        eventsInWindow: eventCount,
+        eventsPerMinute: eventRate === null ? null : round(eventRate),
+      };
+
+      return [window, metrics] as const;
+    }),
+  ) as Record<ThroughputWindow, ThroughputWindowMetrics>;
+}
+
+export function buildThroughputSeries(
+  snapshot: OfficeSnapshot,
+  window: ThroughputWindow,
+  options: ThroughputSeriesOptions = {},
+): ThroughputSeriesBucket[] {
+  const now = options.now ?? snapshot.generatedAt;
+  const bucketCount = Math.max(4, Math.min(30, options.bucketCount ?? 12));
+  const runStats = selectRunStats(snapshot, options);
+  const bounds = resolveBounds(window, now);
+  const span = Math.max(1, bounds.endAt - bounds.startAt);
+  const step = Math.max(1, Math.floor(span / bucketCount));
+
+  return Array.from({ length: bucketCount }, (_, index) => {
+    const bucketStart = bounds.startAt + index * step;
+    const bucketEnd = index === bucketCount - 1 ? bounds.endAt : Math.min(bounds.endAt, bucketStart + step - 1);
+    const bucketBounds: WindowBounds = { startAt: bucketStart, endAt: bucketEnd };
+
+    const startedRuns = runStats.filter((item) => withinRange(item.startedAt, bucketBounds)).length;
+    const completedRuns = runStats.filter(
+      (item) => item.completedAt !== null && withinRange(item.completedAt, bucketBounds),
+    );
+
+    return {
+      index,
+      startAt: bucketStart,
+      endAt: bucketEnd,
+      label: toTimeLabel(bucketEnd, window),
+      startedRuns,
+      completedRuns: completedRuns.length,
+      errorRuns: completedRuns.filter((item) => item.run.status === "error").length,
+      maxConcurrency: peakConcurrency(runStats, bucketBounds),
+    };
+  });
+}
+
+export function buildAgentThroughputBreakdown(
+  snapshot: OfficeSnapshot,
+  window: ThroughputWindow,
+  options: DashboardSelectionOptions = {},
+): ThroughputAgentMetrics[] {
+  const now = options.now ?? snapshot.generatedAt;
+  const bounds = resolveBounds(window, now);
+  const runStats = selectRunStats(snapshot, options);
+
+  const statsByAgent = new Map<string, RunStats[]>();
+  for (const item of runStats) {
+    if (!withinRange(item.startedAt, bounds)) {
+      continue;
+    }
+    const bucket = statsByAgent.get(item.run.childAgentId);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      statsByAgent.set(item.run.childAgentId, [item]);
+    }
+  }
+
+  const eventsByAgent = new Map<string, number>();
+  for (const event of snapshot.events) {
+    if (!withinRange(event.at, bounds)) {
+      continue;
+    }
+    eventsByAgent.set(event.agentId, (eventsByAgent.get(event.agentId) ?? 0) + 1);
+  }
+
+  return [...statsByAgent.entries()]
+    .map(([agentId, items]) => {
+      const completed = items.filter((item) => item.completedAt !== null);
+      const durations = completed
+        .map((item) => item.durationMs)
+        .filter((value): value is number => typeof value === "number");
+      const activeRuns = items.filter((item) => item.run.status === "active").length;
+      const latestRunAt = items.reduce(
+        (latest, item) => Math.max(latest, item.completedAt ?? item.startedAt),
+        0,
+      );
+
+      return {
+        agentId,
+        startedRuns: items.length,
+        completedRuns: completed.length,
+        activeRuns,
+        completionRate: ratio(completed.length, items.length),
+        avgDurationMs:
+          durations.length === 0
+            ? null
+            : round(durations.reduce((sum, value) => sum + value, 0) / durations.length, 0),
+        errorRatio: ratio(
+          completed.filter((item) => item.run.status === "error").length,
+          completed.length,
+        ),
+        eventCount: eventsByAgent.get(agentId) ?? 0,
+        latestRunAt,
+      } satisfies ThroughputAgentMetrics;
+    })
+    .sort((left, right) => {
+      if (left.startedRuns !== right.startedRuns) {
+        return right.startedRuns - left.startedRuns;
+      }
+      if (left.activeRuns !== right.activeRuns) {
+        return right.activeRuns - left.activeRuns;
+      }
+      const leftErrorRatio = left.errorRatio ?? -1;
+      const rightErrorRatio = right.errorRatio ?? -1;
+      if (leftErrorRatio !== rightErrorRatio) {
+        return rightErrorRatio - leftErrorRatio;
+      }
+      if (left.latestRunAt !== right.latestRunAt) {
+        return right.latestRunAt - left.latestRunAt;
+      }
+      return left.agentId.localeCompare(right.agentId);
+    });
+}
+
+export function buildThroughputOutliers(
+  snapshot: OfficeSnapshot,
+  window: ThroughputWindow,
+  options: DashboardSelectionOptions = {},
+): ThroughputOutlier[] {
+  const now = options.now ?? snapshot.generatedAt;
+  const bounds = resolveBounds(window, now);
+  const runStats = selectRunStats(snapshot, options)
+    .filter((item) => withinRange(item.startedAt, bounds))
+    .filter((item) => item.completedAt !== null && item.durationMs !== null);
+
+  const outliers: ThroughputOutlier[] = [];
+  const durations = runStats
+    .map((item) => item.durationMs)
+    .filter((value): value is number => typeof value === "number");
+  const slowThreshold = percentile(durations, 0.9);
+
+  if (slowThreshold !== null && durations.length >= 3) {
+    const slowRuns = runStats
+      .filter((item) => (item.durationMs ?? 0) >= slowThreshold)
+      .sort((left, right) => (right.durationMs ?? 0) - (left.durationMs ?? 0))
+      .slice(0, 3);
+
+    for (const item of slowRuns) {
+      outliers.push({
+        id: `slow:${item.run.runId}`,
+        severity: "high",
+        title: `Slow run ${item.run.runId}`,
+        detail: `${item.run.childAgentId} took ${Math.round((item.durationMs ?? 0) / 1000)}s`,
+        agentId: item.run.childAgentId,
+        runId: item.run.runId,
+      });
+    }
+  }
+
+  const agentBreakdown = buildAgentThroughputBreakdown(snapshot, window, options);
+  for (const agent of agentBreakdown) {
+    if (agent.completedRuns >= 2 && (agent.errorRatio ?? 0) >= 0.5) {
+      outliers.push({
+        id: `error:${agent.agentId}`,
+        severity: "high",
+        title: `Error hotspot ${agent.agentId}`,
+        detail: `${Math.round((agent.errorRatio ?? 0) * 100)}% of completed runs failed`,
+        agentId: agent.agentId,
+      });
+    }
+    if (agent.startedRuns >= 3 && (agent.completionRate ?? 1) < 0.5) {
+      outliers.push({
+        id: `completion:${agent.agentId}`,
+        severity: "medium",
+        title: `Low completion ${agent.agentId}`,
+        detail: `${agent.completedRuns}/${agent.startedRuns} runs completed in this window`,
+        agentId: agent.agentId,
+      });
+    }
+  }
+
+  return outliers
+    .slice(0, 6)
+    .sort((left, right) => {
+      if (left.severity !== right.severity) {
+        return left.severity === "high" ? -1 : 1;
+      }
+      return left.title.localeCompare(right.title);
+    });
+}


### PR DESCRIPTION
## Summary\n- add a new throughput dashboard section with 5m/1h/24h window comparison\n- implement KPI calculators for completion rate, average duration, active concurrency, and error ratio\n- add bucketed trend chart, agent drill-down, and outlier highlights\n- cover KPI calculations and outlier detection with unit tests\n\n## Validation\n- pnpm ci:local\n\nCloses #27