### PR TITLE
feat: add daily/incident summary exporter

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -516,6 +516,57 @@ body {
   padding: 0 6px 6px;
 }
 
+.summary-exporter {
+  grid-column: 1 / -1;
+  border: 1px solid rgba(146, 225, 255, 0.24);
+  border-radius: 10px;
+  background: rgba(6, 29, 42, 0.72);
+  padding: 8px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.summary-exporter-field {
+  display: grid;
+  gap: 4px;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #9dcfe0;
+}
+
+.summary-exporter-field input,
+.summary-exporter-field select {
+  border-radius: 7px;
+  border: 1px solid rgba(145, 223, 255, 0.34);
+  background: rgba(8, 33, 47, 0.94);
+  color: #def7ff;
+  font-size: 0.68rem;
+  padding: 5px 7px;
+}
+
+.summary-exporter-shots {
+  grid-column: 1 / -1;
+}
+
+.summary-exporter-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.summary-exporter-actions button {
+  border-radius: 7px;
+  border: 1px solid rgba(149, 227, 255, 0.4);
+  background: rgba(9, 39, 55, 0.92);
+  color: #d6f4ff;
+  font-size: 0.66rem;
+  padding: 5px 8px;
+  cursor: pointer;
+}
+
 .ops-actions {
   grid-column: 1 / -1;
   display: flex;
@@ -3030,6 +3081,10 @@ body {
     grid-column: span 2;
   }
 
+  .summary-exporter {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .workspace {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -3145,6 +3200,10 @@ body {
 
   .ops-search {
     grid-column: span 1;
+  }
+
+  .summary-exporter {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .ops-match-count {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { CommandPalette, type CommandPaletteEntry } from "./components/CommandPa
 import { EntityDetailPanel } from "./components/EntityDetailPanel";
 import { EventRail } from "./components/EventRail";
 import { OfficeStage } from "./components/OfficeStage";
+import { SummaryExporter } from "./components/SummaryExporter";
 import { ThroughputDashboard } from "./components/ThroughputDashboard";
 import { useOfficeStream } from "./hooks/useOfficeStream";
 import {
@@ -1370,6 +1371,15 @@ function App() {
           />
           Focus mode ({focusModeShortcutLabel})
         </label>
+
+        <SummaryExporter
+          snapshot={snapshot}
+          defaultAgentId={selectedEntity?.agentId ?? activeEvent?.agentId ?? null}
+          defaultRunId={
+            selectedRun?.runId ?? selectedEntity?.runId ?? activeEvent?.runId ?? null
+          }
+          onNotify={showToast}
+        />
 
         <div className="ops-actions">
           <button type="button" onClick={toggleCommandPalette}>

--- a/src/components/SummaryExporter.tsx
+++ b/src/components/SummaryExporter.tsx
@@ -1,0 +1,210 @@
+import { useMemo, useState } from "react";
+import {
+  buildSummaryFilename,
+  buildSummaryReport,
+  downloadTextArtifact,
+  renderSummaryMarkdown,
+  serializeSummaryReportJson,
+  type SummaryTemplate,
+  type SummaryWindow,
+} from "../lib/summary-exporter";
+import type { OfficeSnapshot } from "../types/office";
+
+type Props = {
+  snapshot: OfficeSnapshot;
+  defaultAgentId?: string | null;
+  defaultRunId?: string | null;
+  onNotify?: (kind: "success" | "error" | "info", message: string) => void;
+};
+
+const TEMPLATE_OPTIONS: Array<{ value: SummaryTemplate; label: string }> = [
+  { value: "daily", label: "Daily" },
+  { value: "incident", label: "Incident" },
+];
+
+const WINDOW_OPTIONS: Array<{ value: SummaryWindow; label: string }> = [
+  { value: "5m", label: "5m" },
+  { value: "1h", label: "1h" },
+  { value: "24h", label: "24h" },
+  { value: "all", label: "All" },
+];
+
+function parseScreenshotPaths(input: string): string[] {
+  return input
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+export function SummaryExporter({
+  snapshot,
+  defaultAgentId = null,
+  defaultRunId = null,
+  onNotify,
+}: Props) {
+  const [template, setTemplate] = useState<SummaryTemplate>("daily");
+  const [windowScope, setWindowScope] = useState<SummaryWindow>("1h");
+  const [agentId, setAgentId] = useState(defaultAgentId ?? "");
+  const [runId, setRunId] = useState(defaultRunId ?? "");
+  const [screenshotsInput, setScreenshotsInput] = useState("");
+
+  const runOptions = useMemo(
+    () => [...snapshot.runs].map((run) => run.runId).sort((left, right) => left.localeCompare(right)),
+    [snapshot.runs],
+  );
+
+  const agentOptions = useMemo(
+    () =>
+      [...new Set(snapshot.entities.filter((entity) => entity.kind === "agent").map((entity) => entity.agentId))]
+        .sort((left, right) => left.localeCompare(right)),
+    [snapshot.entities],
+  );
+
+  const emitNotify = (kind: "success" | "error" | "info", message: string) => {
+    onNotify?.(kind, message);
+  };
+
+  const exportReport = (format: "md" | "json" | "both") => {
+    try {
+      const report = buildSummaryReport(snapshot, template, {
+        window: windowScope,
+        agentId,
+        runId,
+        screenshotPaths: parseScreenshotPaths(screenshotsInput),
+      });
+
+      if (format === "md" || format === "both") {
+        const markdown = renderSummaryMarkdown(report);
+        downloadTextArtifact(
+          buildSummaryFilename(report, "md"),
+          markdown,
+          "text/markdown;charset=utf-8",
+        );
+      }
+      if (format === "json" || format === "both") {
+        const json = serializeSummaryReportJson(report);
+        downloadTextArtifact(
+          buildSummaryFilename(report, "json"),
+          json,
+          "application/json;charset=utf-8",
+        );
+      }
+
+      emitNotify("success", `Exported ${template} summary (${format.toUpperCase()}).`);
+    } catch (errorValue) {
+      console.error("Summary export failed", errorValue);
+      emitNotify("error", "Failed to export summary report.");
+    }
+  };
+
+  return (
+    <section className="summary-exporter" aria-label="Summary exporter">
+      <label className="summary-exporter-field">
+        Template
+        <select
+          value={template}
+          onChange={(event) => {
+            setTemplate(event.target.value as SummaryTemplate);
+          }}
+        >
+          {TEMPLATE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="summary-exporter-field">
+        Window
+        <select
+          value={windowScope}
+          onChange={(event) => {
+            setWindowScope(event.target.value as SummaryWindow);
+          }}
+        >
+          {WINDOW_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="summary-exporter-field">
+        Agent
+        <input
+          type="text"
+          list="summary-export-agent-options"
+          placeholder="all agents"
+          value={agentId}
+          onChange={(event) => {
+            setAgentId(event.target.value);
+          }}
+        />
+        <datalist id="summary-export-agent-options">
+          {agentOptions.map((option) => (
+            <option key={option} value={option} />
+          ))}
+        </datalist>
+      </label>
+
+      <label className="summary-exporter-field">
+        Run
+        <input
+          type="text"
+          list="summary-export-run-options"
+          placeholder="all runs"
+          value={runId}
+          onChange={(event) => {
+            setRunId(event.target.value);
+          }}
+        />
+        <datalist id="summary-export-run-options">
+          {runOptions.map((option) => (
+            <option key={option} value={option} />
+          ))}
+        </datalist>
+      </label>
+
+      <label className="summary-exporter-field summary-exporter-shots">
+        Screenshot Paths (comma)
+        <input
+          type="text"
+          placeholder="./shots/latest.png, ./shots/failure.png"
+          value={screenshotsInput}
+          onChange={(event) => {
+            setScreenshotsInput(event.target.value);
+          }}
+        />
+      </label>
+
+      <div className="summary-exporter-actions">
+        <button
+          type="button"
+          onClick={() => {
+            exportReport("md");
+          }}
+        >
+          Export MD
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            exportReport("json");
+          }}
+        >
+          Export JSON
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            exportReport("both");
+          }}
+        >
+          Export Both
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/summary-exporter.test.ts
+++ b/src/lib/summary-exporter.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { createLocal50Scenario } from "./local50-scenario";
+import {
+  buildSummaryFilename,
+  buildSummaryReport,
+  renderSummaryMarkdown,
+  serializeSummaryReportJson,
+} from "./summary-exporter";
+
+describe("summary exporter", () => {
+  it("builds filtered summary report schema for downstream automation", () => {
+    const { snapshot } = createLocal50Scenario({
+      profile: "local10",
+      seed: 14,
+      seedTime: 1_700_000_000_000,
+    });
+    const targetRun = snapshot.runs[0];
+
+    const report = buildSummaryReport(snapshot, "daily", {
+      window: "1h",
+      runId: targetRun?.runId,
+      screenshotPaths: [" ./shots/latest.png ", "./shots/latest.png", "./shots/error.png"],
+    });
+
+    expect(report.schemaVersion).toBe("1.0");
+    expect(report.filters.window).toBe("1h");
+    expect(report.filters.runId).toBe(targetRun?.runId ?? null);
+    expect(report.filters.screenshotPaths).toEqual([
+      "./shots/latest.png",
+      "./shots/error.png",
+    ]);
+    expect(report.kpis.startedRuns).toBeGreaterThanOrEqual(0);
+    expect(report.recentEvents.every((event) => event.runId === (targetRun?.runId ?? event.runId))).toBe(true);
+  });
+
+  it("renders daily and incident markdown templates with required sections", () => {
+    const { snapshot } = createLocal50Scenario({
+      profile: "local10",
+      seed: 22,
+      seedTime: 1_700_000_050_000,
+    });
+
+    const daily = buildSummaryReport(snapshot, "daily", {
+      window: "24h",
+      screenshotPaths: ["./shots/daily.png"],
+    });
+    const incident = buildSummaryReport(snapshot, "incident", {
+      window: "24h",
+      screenshotPaths: ["./shots/incident.png"],
+    });
+
+    const dailyMd = renderSummaryMarkdown(daily);
+    const incidentMd = renderSummaryMarkdown(incident);
+
+    expect(dailyMd).toContain("# Daily Operations Summary");
+    expect(dailyMd).toContain("## KPI Snapshot");
+    expect(dailyMd).toContain("## Failed Runs");
+    expect(dailyMd).toContain("./shots/daily.png");
+
+    expect(incidentMd).toContain("# Incident Summary");
+    expect(incidentMd).toContain("## Incident Context");
+    expect(incidentMd).toContain("## Failure Timeline");
+    expect(incidentMd).toContain("./shots/incident.png");
+  });
+
+  it("serializes json payload and deterministic filenames", () => {
+    const { snapshot } = createLocal50Scenario({
+      profile: "local10",
+      seed: 37,
+      seedTime: 1_700_000_100_000,
+    });
+
+    const report = buildSummaryReport(snapshot, "daily", {
+      window: "5m",
+    });
+
+    const json = serializeSummaryReportJson(report);
+    const filename = buildSummaryFilename(report, "json");
+
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(filename).toMatch(/^openclaw-daily-summary-[0-9-]+\.json$/);
+  });
+});

--- a/src/lib/summary-exporter.ts
+++ b/src/lib/summary-exporter.ts
@@ -1,0 +1,566 @@
+import type { OfficeEvent, OfficeRun, OfficeSnapshot } from "../types/office";
+
+export type SummaryTemplate = "daily" | "incident";
+export type SummaryWindow = "5m" | "1h" | "24h" | "all";
+
+export type SummaryExportFilters = {
+  window: SummaryWindow;
+  agentId?: string;
+  runId?: string;
+  screenshotPaths?: string[];
+};
+
+export type SummaryKpis = {
+  startedRuns: number;
+  completedRuns: number;
+  failedRuns: number;
+  completionRate: number | null;
+  avgDurationMs: number | null;
+  errorRatio: number | null;
+  activeConcurrency: number;
+  eventCount: number;
+};
+
+export type SummaryTopAgent = {
+  agentId: string;
+  startedRuns: number;
+  completedRuns: number;
+  failedRuns: number;
+  activeRuns: number;
+  avgDurationMs: number | null;
+};
+
+export type SummaryFailedRun = {
+  runId: string;
+  childAgentId: string;
+  parentAgentId: string;
+  task: string;
+  durationMs: number | null;
+  endedAt: number | null;
+};
+
+export type SummaryEventRecord = {
+  id: string;
+  type: OfficeEvent["type"];
+  runId: string;
+  agentId: string;
+  at: number;
+  text: string;
+};
+
+export type SummaryReport = {
+  schemaVersion: "1.0";
+  template: SummaryTemplate;
+  generatedAt: number;
+  generatedAtIso: string;
+  filters: {
+    window: SummaryWindow;
+    fromAt: number | null;
+    toAt: number;
+    agentId: string | null;
+    runId: string | null;
+    screenshotPaths: string[];
+  };
+  kpis: SummaryKpis;
+  highlights: string[];
+  topAgents: SummaryTopAgent[];
+  failedRuns: SummaryFailedRun[];
+  recentEvents: SummaryEventRecord[];
+  screenshots: string[];
+};
+
+const WINDOW_MS: Record<Exclude<SummaryWindow, "all">, number> = {
+  "5m": 5 * 60_000,
+  "1h": 60 * 60_000,
+  "24h": 24 * 60 * 60_000,
+};
+
+function round(value: number, digits = 2): number {
+  const multiplier = 10 ** digits;
+  return Math.round(value * multiplier) / multiplier;
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+function normalizeFilterValue(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeScreenshotPaths(paths: string[] | undefined): string[] {
+  if (!paths) {
+    return [];
+  }
+  const unique = new Set<string>();
+  for (const path of paths) {
+    const normalized = path.trim();
+    if (!normalized) {
+      continue;
+    }
+    unique.add(normalized);
+  }
+  return [...unique];
+}
+
+function runStartedAt(run: OfficeRun): number {
+  return run.startedAt ?? run.createdAt;
+}
+
+function runCompletedAt(run: OfficeRun): number | null {
+  if (run.status === "active") {
+    return null;
+  }
+  return run.endedAt ?? run.cleanupCompletedAt ?? null;
+}
+
+function runDurationMs(run: OfficeRun): number | null {
+  const startedAt = runStartedAt(run);
+  const completedAt = runCompletedAt(run);
+  if (completedAt === null) {
+    return null;
+  }
+  return Math.max(0, completedAt - startedAt);
+}
+
+function resolveBounds(snapshot: OfficeSnapshot, window: SummaryWindow): {
+  fromAt: number | null;
+  toAt: number;
+} {
+  const toAt = snapshot.generatedAt;
+  if (window === "all") {
+    return {
+      fromAt: null,
+      toAt,
+    };
+  }
+  return {
+    fromAt: toAt - WINDOW_MS[window],
+    toAt,
+  };
+}
+
+function matchesTime(at: number, bounds: { fromAt: number | null; toAt: number }): boolean {
+  if (at > bounds.toAt) {
+    return false;
+  }
+  if (bounds.fromAt === null) {
+    return true;
+  }
+  return at >= bounds.fromAt;
+}
+
+function filterRuns(
+  snapshot: OfficeSnapshot,
+  bounds: { fromAt: number | null; toAt: number },
+  agentId: string | null,
+  runId: string | null,
+): OfficeRun[] {
+  return snapshot.runs.filter((run) => {
+    if (!matchesTime(runStartedAt(run), bounds)) {
+      return false;
+    }
+    if (runId && run.runId !== runId) {
+      return false;
+    }
+    if (agentId && run.childAgentId !== agentId && run.parentAgentId !== agentId) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function filterEvents(
+  snapshot: OfficeSnapshot,
+  bounds: { fromAt: number | null; toAt: number },
+  agentId: string | null,
+  runId: string | null,
+): OfficeEvent[] {
+  return snapshot.events.filter((event) => {
+    if (!matchesTime(event.at, bounds)) {
+      return false;
+    }
+    if (runId && event.runId !== runId) {
+      return false;
+    }
+    if (agentId && event.agentId !== agentId && event.parentAgentId !== agentId) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function peakConcurrency(
+  runs: OfficeRun[],
+  bounds: { fromAt: number | null; toAt: number },
+): number {
+  if (runs.length === 0) {
+    return 0;
+  }
+  const fromAt = bounds.fromAt ?? Number.NEGATIVE_INFINITY;
+  const toAt = bounds.toAt;
+  const deltas = new Map<number, number>();
+
+  for (const run of runs) {
+    const startAt = runStartedAt(run);
+    const endAt = runCompletedAt(run) ?? toAt;
+    if (endAt < fromAt || startAt > toAt) {
+      continue;
+    }
+    const visibleStart = Math.max(startAt, fromAt);
+    const visibleEnd = Math.min(endAt, toAt);
+
+    deltas.set(visibleStart, (deltas.get(visibleStart) ?? 0) + 1);
+    deltas.set(visibleEnd + 1, (deltas.get(visibleEnd + 1) ?? 0) - 1);
+  }
+
+  let current = 0;
+  let peak = 0;
+  const sorted = [...deltas.entries()].sort((left, right) => left[0] - right[0]);
+  for (const [, delta] of sorted) {
+    current += delta;
+    if (current > peak) {
+      peak = current;
+    }
+  }
+  return peak;
+}
+
+function buildHighlights(kpis: SummaryKpis, failedRuns: SummaryFailedRun[]): string[] {
+  const highlights: string[] = [];
+
+  if (kpis.startedRuns === 0) {
+    highlights.push("No runs matched the selected filter scope.");
+    return highlights;
+  }
+
+  if (kpis.completionRate !== null && kpis.completionRate < 0.75) {
+    highlights.push(`Completion rate dropped to ${Math.round(kpis.completionRate * 100)}%.`);
+  }
+  if (kpis.errorRatio !== null && kpis.errorRatio >= 0.25) {
+    highlights.push(`Error ratio is elevated at ${Math.round(kpis.errorRatio * 100)}%.`);
+  }
+  if (kpis.avgDurationMs !== null && kpis.avgDurationMs >= 180_000) {
+    highlights.push(`Average run duration reached ${(kpis.avgDurationMs / 1000).toFixed(1)}s.`);
+  }
+  if (kpis.activeConcurrency >= 10) {
+    highlights.push(`High concurrency observed (peak ${kpis.activeConcurrency}).`);
+  }
+  if (failedRuns.length > 0) {
+    highlights.push(`${failedRuns.length} failed runs captured in this report.`);
+  }
+  if (highlights.length === 0) {
+    highlights.push("System stayed within normal range for the selected period.");
+  }
+  return highlights;
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatDuration(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+  if (value < 1000) {
+    return `${value}ms`;
+  }
+  if (value < 60_000) {
+    return `${(value / 1000).toFixed(1)}s`;
+  }
+  return `${(value / 60_000).toFixed(1)}m`;
+}
+
+function formatDatetime(value: number | null): string {
+  if (value === null) {
+    return "-";
+  }
+  return new Date(value).toLocaleString();
+}
+
+export function buildSummaryReport(
+  snapshot: OfficeSnapshot,
+  template: SummaryTemplate,
+  filters: SummaryExportFilters,
+): SummaryReport {
+  const bounds = resolveBounds(snapshot, filters.window);
+  const normalizedAgentId = normalizeFilterValue(filters.agentId);
+  const normalizedRunId = normalizeFilterValue(filters.runId);
+  const screenshots = normalizeScreenshotPaths(filters.screenshotPaths);
+
+  const runs = filterRuns(snapshot, bounds, normalizedAgentId, normalizedRunId);
+  const events = filterEvents(snapshot, bounds, normalizedAgentId, normalizedRunId).sort(
+    (left, right) => right.at - left.at,
+  );
+
+  const completedRuns = runs.filter((run) => runCompletedAt(run) !== null);
+  const failedRuns = completedRuns
+    .filter((run) => run.status === "error")
+    .map((run) => ({
+      runId: run.runId,
+      childAgentId: run.childAgentId,
+      parentAgentId: run.parentAgentId,
+      task: run.task,
+      durationMs: runDurationMs(run),
+      endedAt: runCompletedAt(run),
+    }))
+    .sort((left, right) => (right.endedAt ?? 0) - (left.endedAt ?? 0));
+
+  const completedDurations = completedRuns
+    .map((run) => runDurationMs(run))
+    .filter((value): value is number => typeof value === "number");
+
+  const kpis: SummaryKpis = {
+    startedRuns: runs.length,
+    completedRuns: completedRuns.length,
+    failedRuns: failedRuns.length,
+    completionRate: ratio(completedRuns.length, runs.length),
+    avgDurationMs:
+      completedDurations.length === 0
+        ? null
+        : round(
+            completedDurations.reduce((sum, value) => sum + value, 0) / completedDurations.length,
+            0,
+          ),
+    errorRatio: ratio(failedRuns.length, completedRuns.length),
+    activeConcurrency: peakConcurrency(runs, bounds),
+    eventCount: events.length,
+  };
+
+  const topAgents = [...runs
+    .reduce((map, run) => {
+      const bucket = map.get(run.childAgentId) ?? {
+        agentId: run.childAgentId,
+        startedRuns: 0,
+        completedRuns: 0,
+        failedRuns: 0,
+        activeRuns: 0,
+        durations: [] as number[],
+      };
+      bucket.startedRuns += 1;
+      if (run.status === "active") {
+        bucket.activeRuns += 1;
+      }
+      const duration = runDurationMs(run);
+      if (duration !== null) {
+        bucket.completedRuns += 1;
+        bucket.durations.push(duration);
+      }
+      if (run.status === "error") {
+        bucket.failedRuns += 1;
+      }
+      map.set(run.childAgentId, bucket);
+      return map;
+    }, new Map<string, {
+      agentId: string;
+      startedRuns: number;
+      completedRuns: number;
+      failedRuns: number;
+      activeRuns: number;
+      durations: number[];
+    }>())
+    .values()]
+    .map((entry) => ({
+      agentId: entry.agentId,
+      startedRuns: entry.startedRuns,
+      completedRuns: entry.completedRuns,
+      failedRuns: entry.failedRuns,
+      activeRuns: entry.activeRuns,
+      avgDurationMs:
+        entry.durations.length === 0
+          ? null
+          : round(entry.durations.reduce((sum, value) => sum + value, 0) / entry.durations.length, 0),
+    }))
+    .sort((left, right) => {
+      if (left.startedRuns !== right.startedRuns) {
+        return right.startedRuns - left.startedRuns;
+      }
+      if (left.failedRuns !== right.failedRuns) {
+        return right.failedRuns - left.failedRuns;
+      }
+      return left.agentId.localeCompare(right.agentId);
+    })
+    .slice(0, 6);
+
+  const recentEvents: SummaryEventRecord[] = events.slice(0, 14).map((event) => ({
+    id: event.id,
+    type: event.type,
+    runId: event.runId,
+    agentId: event.agentId,
+    at: event.at,
+    text: event.text,
+  }));
+
+  return {
+    schemaVersion: "1.0",
+    template,
+    generatedAt: snapshot.generatedAt,
+    generatedAtIso: new Date(snapshot.generatedAt).toISOString(),
+    filters: {
+      window: filters.window,
+      fromAt: bounds.fromAt,
+      toAt: bounds.toAt,
+      agentId: normalizedAgentId,
+      runId: normalizedRunId,
+      screenshotPaths: screenshots,
+    },
+    kpis,
+    highlights: buildHighlights(kpis, failedRuns),
+    topAgents,
+    failedRuns: failedRuns.slice(0, 12),
+    recentEvents,
+    screenshots,
+  };
+}
+
+function renderKpiTable(kpis: SummaryKpis): string {
+  return [
+    "| KPI | Value |",
+    "| --- | --- |",
+    `| Started runs | ${kpis.startedRuns} |`,
+    `| Completed runs | ${kpis.completedRuns} |`,
+    `| Failed runs | ${kpis.failedRuns} |`,
+    `| Completion rate | ${formatPercent(kpis.completionRate)} |`,
+    `| Error ratio | ${formatPercent(kpis.errorRatio)} |`,
+    `| Avg duration | ${formatDuration(kpis.avgDurationMs)} |`,
+    `| Peak concurrency | ${kpis.activeConcurrency} |`,
+    `| Event count | ${kpis.eventCount} |`,
+  ].join("\n");
+}
+
+function renderTopAgents(topAgents: SummaryTopAgent[]): string {
+  if (topAgents.length === 0) {
+    return "No agent-level activity in this scope.";
+  }
+  const lines = [
+    "| Agent | Started | Completed | Failed | Active | Avg Duration |",
+    "| --- | --- | --- | --- | --- | --- |",
+  ];
+  for (const agent of topAgents) {
+    lines.push(
+      `| ${agent.agentId} | ${agent.startedRuns} | ${agent.completedRuns} | ${agent.failedRuns} | ${agent.activeRuns} | ${formatDuration(agent.avgDurationMs)} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function renderFailedRuns(failedRuns: SummaryFailedRun[]): string {
+  if (failedRuns.length === 0) {
+    return "No failed runs in this scope.";
+  }
+  return failedRuns
+    .map(
+      (run) =>
+        `- \`${run.runId}\` (${run.childAgentId}) at ${formatDatetime(run.endedAt)} | duration ${formatDuration(run.durationMs)} | ${run.task}`,
+    )
+    .join("\n");
+}
+
+function renderRecentEvents(events: SummaryEventRecord[]): string {
+  if (events.length === 0) {
+    return "No events in this scope.";
+  }
+  return events
+    .map(
+      (event) =>
+        `- ${new Date(event.at).toLocaleTimeString()} [${event.type}] \`${event.runId}\` ${event.agentId} - ${event.text}`,
+    )
+    .join("\n");
+}
+
+function renderScreenshotSection(screenshots: string[]): string {
+  if (screenshots.length === 0) {
+    return "- (none provided)";
+  }
+  return screenshots.map((path) => `- [${path}](${path})`).join("\n");
+}
+
+export function renderSummaryMarkdown(report: SummaryReport): string {
+  const header =
+    report.template === "incident" ? "Incident Summary" : "Daily Operations Summary";
+  const scopeLines = [
+    `- Generated: ${new Date(report.generatedAt).toLocaleString()}`,
+    `- Window: ${report.filters.window}`,
+    `- Agent filter: ${report.filters.agentId ?? "all"}`,
+    `- Run filter: ${report.filters.runId ?? "all"}`,
+  ];
+
+  const incidentIntro =
+    report.template === "incident"
+      ? [
+          "## Incident Context",
+          report.highlights.map((line) => `- ${line}`).join("\n"),
+          "",
+          "## Impact Metrics",
+          renderKpiTable(report.kpis),
+        ]
+      : [
+          "## KPI Snapshot",
+          renderKpiTable(report.kpis),
+          "",
+          "## Highlights",
+          report.highlights.map((line) => `- ${line}`).join("\n"),
+        ];
+
+  const sections = [
+    `# ${header}`,
+    "",
+    "## Scope",
+    scopeLines.join("\n"),
+    "",
+    ...incidentIntro,
+    "",
+    "## Top Agents",
+    renderTopAgents(report.topAgents),
+    "",
+    report.template === "incident" ? "## Failure Timeline" : "## Failed Runs",
+    renderFailedRuns(report.failedRuns),
+    "",
+    report.template === "incident" ? "## Timeline Evidence" : "## Recent Events",
+    renderRecentEvents(report.recentEvents),
+    "",
+    "## Screenshot Links",
+    renderScreenshotSection(report.screenshots),
+  ];
+
+  return sections.join("\n").trimEnd();
+}
+
+export function serializeSummaryReportJson(report: SummaryReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function buildSummaryFilename(
+  report: SummaryReport,
+  format: "md" | "json",
+): string {
+  const stamp = new Date(report.generatedAt)
+    .toISOString()
+    .replace(/[:]/g, "-")
+    .replace(/\..+$/, "")
+    .replace("T", "-");
+  return `openclaw-${report.template}-summary-${stamp}.${format}`;
+}
+
+export function downloadTextArtifact(filename: string, content: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const href = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(href);
+}


### PR DESCRIPTION
## Summary\n- define a reusable summary report schema for operations exports\n- implement report builder with window/agent/run filters and KPI sections\n- add two markdown templates (daily and incident) plus JSON serialization\n- add exporter UI controls for filter inputs and MD/JSON download actions\n- add unit tests for report generation, template rendering, and filenames\n\n## Validation\n- pnpm ci:local\n\nCloses #29