### PR TITLE
feat(layout): add 50-agent capacity planning and auto distribution

### DIFF
--- a/src/components/OfficeStage.tsx
+++ b/src/components/OfficeStage.tsx
@@ -1505,10 +1505,12 @@ export function OfficeStage({
                 <span>
                   cap {debug.assigned}/{debug.capacity}
                 </span>
-                <span>occ {occupancyPercent}%</span>
+                <span>occ {debug.utilizationPct || occupancyPercent}%</span>
                 <span>target {debug.targeted}</span>
+                <span>{debug.saturation}</span>
                 {debug.overflowOut > 0 ? <span>out +{debug.overflowOut}</span> : null}
                 {debug.overflowIn > 0 ? <span>in +{debug.overflowIn}</span> : null}
+                {debug.manualOverrides > 0 ? <span>override {debug.manualOverrides}</span> : null}
               </div>
             ) : null}
           </section>


### PR DESCRIPTION
## Summary
- add explicit room capacity planning output (`buildRoomCapacityPlan`) for local50 target sizing
- extend placement routing with team-priority scoring, occupancy-aware tie-breaking, and manual room override hints (`[room:<id>]`, `room:<id>`)
- enrich room debug telemetry (utilization/saturation/manual overrides) and display it on stage room cards
- add coverage for capacity plan, team-aware distribution, manual overrides, and local50 agent simulation

## Validation
- pnpm ci:local

Closes #34
