### PR TITLE
[Visual] Zoom 기반 LOD(Level of Detail) 렌더링

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1144,6 +1144,17 @@ body {
   filter: none;
 }
 
+.run-link.lod-distant {
+  stroke-width: 1.4;
+  stroke-dasharray: 2 9;
+  opacity: 0.42;
+}
+
+.run-link.lod-mid {
+  stroke-width: 1.9;
+  stroke-dasharray: 4 6;
+}
+
 .run-link.run-ok {
   stroke: #85ffc4;
   opacity: 0.54;
@@ -1309,6 +1320,50 @@ body {
 .entity-token .token-meta span {
   font-size: 0.67rem;
   color: #b0dceb;
+}
+
+.office-stage-wrap .entity-token .sprite-shell,
+.office-stage-wrap .entity-token .token-meta,
+.office-stage-wrap .entity-token .sprite {
+  transition:
+    width var(--motion-mid) ease,
+    height var(--motion-mid) ease,
+    transform var(--motion-mid) ease,
+    opacity var(--motion-mid) ease;
+}
+
+.office-stage-wrap.lod-distant .entity-token {
+  min-width: 56px;
+}
+
+.office-stage-wrap.lod-distant .entity-token .sprite-shell {
+  width: 36px;
+  height: 36px;
+  border-radius: 11px;
+}
+
+.office-stage-wrap.lod-distant .entity-token .sprite {
+  transform: scale(1.78);
+}
+
+.office-stage-wrap.lod-distant .entity-token .sprite-fallback {
+  font-size: 0.62rem;
+}
+
+.office-stage-wrap.lod-distant .entity-token .token-meta {
+  opacity: 0;
+}
+
+.office-stage-wrap.lod-mid .entity-token .token-meta span {
+  display: none;
+}
+
+.office-stage-wrap.lod-mid .entity-token .token-meta strong {
+  font-size: 0.7rem;
+}
+
+.office-stage-wrap.lod-distant .bubble-lane-overlay {
+  display: none;
 }
 
 .entity-token .bubble {

--- a/src/lib/stage-lod.test.ts
+++ b/src/lib/stage-lod.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { BubbleLaneLayout } from "./bubble-lanes";
+import {
+  projectBubbleLaneLayoutForLod,
+  resolveStageLodLevel,
+  shouldRenderRunLinkForLod,
+} from "./stage-lod";
+
+describe("stage LOD helpers", () => {
+  it("resolves zoom into distant/mid/detail levels", () => {
+    expect(resolveStageLodLevel(0.8)).toBe("distant");
+    expect(resolveStageLodLevel(0.92)).toBe("distant");
+    expect(resolveStageLodLevel(1.05)).toBe("mid");
+    expect(resolveStageLodLevel(1.38)).toBe("mid");
+    expect(resolveStageLodLevel(1.6)).toBe("detail");
+  });
+
+  it("filters run link rendering by lod and highlight state", () => {
+    expect(
+      shouldRenderRunLinkForLod({
+        lodLevel: "distant",
+        hasHighlight: false,
+        runStatus: "active",
+        runAgeMs: 20_000,
+        runRecentWindowMs: 10_000,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRenderRunLinkForLod({
+        lodLevel: "distant",
+        hasHighlight: true,
+        runStatus: "ok",
+        runAgeMs: 20_000,
+        runRecentWindowMs: 10_000,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRenderRunLinkForLod({
+        lodLevel: "mid",
+        hasHighlight: false,
+        runStatus: "ok",
+        runAgeMs: 25_000,
+        runRecentWindowMs: 10_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("projects bubble lanes by lod", () => {
+    const layout: BubbleLaneLayout = {
+      lanes: [
+        {
+          id: "lane:a",
+          label: "lane a",
+          y: 30,
+          height: 80,
+          hiddenCount: 0,
+          totalCount: 1,
+        },
+        {
+          id: "lane:b",
+          label: "lane b",
+          y: 120,
+          height: 80,
+          hiddenCount: 2,
+          totalCount: 3,
+        },
+      ],
+      cards: [
+        {
+          id: "card:a",
+          entityId: "entity:a",
+          laneId: "lane:a",
+          laneLabel: "lane a",
+          x: 100,
+          y: 40,
+          width: 200,
+          text: "message",
+          fullText: "message",
+          ageMs: 1_000,
+          isPinned: false,
+          isExpanded: false,
+          isSummary: false,
+          hiddenCount: 0,
+        },
+        {
+          id: "card:b",
+          entityId: "entity:b",
+          laneId: "lane:b",
+          laneLabel: "lane b",
+          x: 120,
+          y: 140,
+          width: 220,
+          text: "summary",
+          fullText: "summary",
+          ageMs: 4_000,
+          isPinned: false,
+          isExpanded: false,
+          isSummary: true,
+          hiddenCount: 2,
+        },
+      ],
+      contentHeight: 220,
+    };
+
+    const distant = projectBubbleLaneLayoutForLod(layout, "distant");
+    expect(distant.cards).toHaveLength(0);
+    expect(distant.lanes).toHaveLength(0);
+
+    const mid = projectBubbleLaneLayoutForLod(layout, "mid");
+    expect(mid.cards).toHaveLength(1);
+    expect(mid.cards[0]?.id).toBe("card:b");
+    expect(mid.lanes).toHaveLength(1);
+    expect(mid.lanes[0]?.id).toBe("lane:b");
+
+    const detail = projectBubbleLaneLayoutForLod(layout, "detail");
+    expect(detail.cards).toHaveLength(2);
+    expect(detail.lanes).toHaveLength(2);
+  });
+});

--- a/src/lib/stage-lod.ts
+++ b/src/lib/stage-lod.ts
@@ -1,0 +1,60 @@
+import type { BubbleLaneCard, BubbleLaneLayout } from "./bubble-lanes";
+import type { OfficeRunStatus } from "../types/office";
+
+export type StageLodLevel = "distant" | "mid" | "detail";
+
+export function resolveStageLodLevel(zoom: number): StageLodLevel {
+  if (zoom <= 0.92) {
+    return "distant";
+  }
+  if (zoom <= 1.38) {
+    return "mid";
+  }
+  return "detail";
+}
+
+export function shouldRenderRunLinkForLod(input: {
+  lodLevel: StageLodLevel;
+  hasHighlight: boolean;
+  runStatus: OfficeRunStatus;
+  runAgeMs: number;
+  runRecentWindowMs: number;
+}): boolean {
+  if (input.lodLevel === "detail") {
+    return true;
+  }
+  if (input.lodLevel === "distant") {
+    return input.hasHighlight;
+  }
+  if (input.runStatus === "ok" && !input.hasHighlight && input.runAgeMs > input.runRecentWindowMs) {
+    return false;
+  }
+  return true;
+}
+
+export function projectBubbleLaneLayoutForLod(
+  layout: Pick<BubbleLaneLayout, "lanes" | "cards">,
+  lodLevel: StageLodLevel,
+): {
+  lanes: BubbleLaneLayout["lanes"];
+  cards: BubbleLaneCard[];
+} {
+  if (lodLevel === "distant") {
+    return {
+      lanes: [],
+      cards: [],
+    };
+  }
+  if (lodLevel === "mid") {
+    const cards = layout.cards.filter((card) => card.isSummary || card.isPinned);
+    const laneIdSet = new Set(cards.map((card) => card.laneId));
+    return {
+      lanes: layout.lanes.filter((lane) => laneIdSet.has(lane.id)),
+      cards,
+    };
+  }
+  return {
+    lanes: layout.lanes,
+    cards: layout.cards,
+  };
+}


### PR DESCRIPTION
## Summary
- add zoom-based stage LOD rules with three levels (`distant`, `mid`, `detail`)
- apply LOD to:
  - run link rendering density
  - bubble lane rendering density
  - entity token icon/meta detail visibility
- add dedicated LOD helper module (`src/lib/stage-lod.ts`) and tests for thresholds and filtering rules
- add smooth transition styling for LOD state changes and run-link LOD styling

## Testing
- pnpm ci:local

Closes #44
