### PR TITLE
[Resilience] 상태 파일 손상 복구/완화 전략

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2973,6 +2973,28 @@ body {
   gap: 4px;
 }
 
+.recovery-banner {
+  border: 1px solid rgba(255, 183, 119, 0.56);
+  border-radius: 12px;
+  background: rgba(61, 35, 19, 0.78);
+  color: #ffd9ad;
+  padding: 10px 12px;
+  display: grid;
+  gap: 4px;
+}
+
+.recovery-banner strong {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.recovery-banner p {
+  margin: 0;
+  font-size: 0.73rem;
+  line-height: 1.4;
+}
+
 .footer-bar {
   display: flex;
   justify-content: space-between;
@@ -3557,6 +3579,10 @@ body {
 
 .error-text {
   color: #ffb9b9;
+}
+
+.recovery-text {
+  color: #ffd39f;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -206,7 +206,7 @@ function workspacePanelPlacementClass(
 }
 
 function App() {
-  const { snapshot, connected, liveSource, error } = useOfficeStream();
+  const { snapshot, connected, liveSource, error, recoveryMessage } = useOfficeStream();
   const [selectedEntityIds, setSelectedEntityIds] = useState<string[]>([]);
   const [activeEventId, setActiveEventId] = useState<string | null>(() => {
     const eventId = parseEventIdDeepLink(window.location.search);
@@ -1372,6 +1372,7 @@ function App() {
           <h1>openClawOffice</h1>
           <p>Loading office state stream...</p>
           {error ? <p className="error-text">{error}</p> : null}
+          {recoveryMessage ? <p className="recovery-text">{recoveryMessage}</p> : null}
         </div>
       </main>
     );
@@ -1427,6 +1428,13 @@ function App() {
           </span>
         </div>
       </section>
+
+      {recoveryMessage ? (
+        <section className="recovery-banner" role="status" aria-live="polite">
+          <strong>Recovery Mode</strong>
+          <p>{recoveryMessage}</p>
+        </section>
+      ) : null}
 
       <section className="stats-bar">
         <StatCard label="Agents" value={agents.length} accent="#81f0ff" />

--- a/src/lib/snapshot-recovery.test.ts
+++ b/src/lib/snapshot-recovery.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { buildRunGraph } from "./run-graph";
+import {
+  hasCorruptedSnapshotInput,
+  resolveSnapshotRecovery,
+  SNAPSHOT_RECOVERY_MESSAGES,
+} from "./snapshot-recovery";
+import type { OfficeSnapshot } from "../types/office";
+
+function makeSnapshot(params?: {
+  generatedAt?: number;
+  diagnostics?: string[];
+}): OfficeSnapshot {
+  const generatedAt = params?.generatedAt ?? 1000;
+  const diagnostics = params?.diagnostics ?? [];
+  return {
+    generatedAt,
+    source: {
+      stateDir: "/tmp/openclawoffice",
+      live: true,
+    },
+    diagnostics: diagnostics.map((code, index) => ({
+      level: "warning",
+      code,
+      source: `state-${index}`,
+      message: `${code} detected`,
+    })),
+    entities: [],
+    runs: [],
+    runGraph: buildRunGraph([]),
+    events: [],
+  };
+}
+
+describe("snapshot recovery", () => {
+  it("detects corrupted snapshot diagnostics by known prefixes", () => {
+    expect(hasCorruptedSnapshotInput(makeSnapshot({ diagnostics: ["JSON_PARSE_FAILED"] }))).toBe(true);
+    expect(hasCorruptedSnapshotInput(makeSnapshot({ diagnostics: ["RUN_ENTRY_INVALID"] }))).toBe(true);
+    expect(hasCorruptedSnapshotInput(makeSnapshot({ diagnostics: ["SESSION_KEY_PARSE_FAILED"] }))).toBe(true);
+    expect(hasCorruptedSnapshotInput(makeSnapshot({ diagnostics: ["RUN_GRAPH_ORPHAN_RUN"] }))).toBe(false);
+  });
+
+  it("keeps incoming snapshot when corruption is not detected", () => {
+    const incoming = makeSnapshot({ generatedAt: 2000, diagnostics: ["RUN_GRAPH_ORPHAN_RUN"] });
+    const lastHealthy = makeSnapshot({ generatedAt: 1500 });
+
+    const resolved = resolveSnapshotRecovery({
+      incoming,
+      lastHealthy,
+    });
+
+    expect(resolved.snapshot).toBe(incoming);
+    expect(resolved.recoveredFromLastHealthy).toBe(false);
+    expect(resolved.recoveryMessage).toBeUndefined();
+  });
+
+  it("restores the last healthy snapshot on corrupted input", () => {
+    const lastHealthy = makeSnapshot({ generatedAt: 1500 });
+    const incoming = makeSnapshot({ generatedAt: 2200, diagnostics: ["RUN_STORE_INVALID_SHAPE"] });
+
+    const resolved = resolveSnapshotRecovery({
+      incoming,
+      lastHealthy,
+    });
+
+    expect(resolved.snapshot).toBe(lastHealthy);
+    expect(resolved.recoveredFromLastHealthy).toBe(true);
+    expect(resolved.recoveryMessage).toBe(SNAPSHOT_RECOVERY_MESSAGES.corruptedSnapshotRecovered);
+  });
+
+  it("keeps corrupted input when no healthy baseline exists", () => {
+    const incoming = makeSnapshot({ generatedAt: 2200, diagnostics: ["JSON_READ_FAILED"] });
+
+    const resolved = resolveSnapshotRecovery({
+      incoming,
+      lastHealthy: null,
+    });
+
+    expect(resolved.snapshot).toBe(incoming);
+    expect(resolved.recoveredFromLastHealthy).toBe(false);
+    expect(resolved.recoveryMessage).toBe(SNAPSHOT_RECOVERY_MESSAGES.corruptedSnapshotNoBaseline);
+  });
+});

--- a/src/lib/snapshot-recovery.ts
+++ b/src/lib/snapshot-recovery.ts
@@ -1,0 +1,53 @@
+import type { OfficeSnapshot } from "../types/office";
+
+const CORRUPTION_DIAGNOSTIC_PREFIXES = ["JSON_", "RUN_", "SESSION_"] as const;
+
+export const SNAPSHOT_RECOVERY_MESSAGES = {
+  corruptedSnapshotRecovered:
+    "Corrupted state input detected. Recovered to the last healthy snapshot.",
+  corruptedSnapshotNoBaseline:
+    "Corrupted state input detected. Waiting for a healthy snapshot baseline.",
+  fetchFallback:
+    "Snapshot refresh failed. Continuing with the last healthy snapshot while retrying.",
+  streamFallback:
+    "Live stream disconnected. Continuing with the last healthy snapshot while reconnecting.",
+  malformedSnapshotFrame:
+    "Malformed snapshot frame ignored. Continuing with the last healthy snapshot.",
+} as const;
+
+export function hasCorruptedSnapshotInput(snapshot: OfficeSnapshot): boolean {
+  return snapshot.diagnostics.some((diagnostic) => {
+    if (diagnostic.code.startsWith("RUN_GRAPH_")) {
+      return false;
+    }
+    return CORRUPTION_DIAGNOSTIC_PREFIXES.some((prefix) => diagnostic.code.startsWith(prefix));
+  });
+}
+
+export function resolveSnapshotRecovery(params: {
+  incoming: OfficeSnapshot;
+  lastHealthy: OfficeSnapshot | null;
+}): {
+  snapshot: OfficeSnapshot;
+  recoveredFromLastHealthy: boolean;
+  recoveryMessage?: string;
+} {
+  if (!hasCorruptedSnapshotInput(params.incoming)) {
+    return {
+      snapshot: params.incoming,
+      recoveredFromLastHealthy: false,
+    };
+  }
+  if (!params.lastHealthy) {
+    return {
+      snapshot: params.incoming,
+      recoveredFromLastHealthy: false,
+      recoveryMessage: SNAPSHOT_RECOVERY_MESSAGES.corruptedSnapshotNoBaseline,
+    };
+  }
+  return {
+    snapshot: params.lastHealthy,
+    recoveredFromLastHealthy: true,
+    recoveryMessage: SNAPSHOT_RECOVERY_MESSAGES.corruptedSnapshotRecovered,
+  };
+}


### PR DESCRIPTION
## Summary\n- add snapshot corruption detection/recovery module with standardized recovery messages\n- restore the last healthy snapshot in stream/poll flows when corrupted input is detected\n- surface a recovery-mode banner so degraded operation is visible without crashing\n- add snapshot recovery unit tests for corruption/fallback behaviors\n\n## Validation\n- pnpm test\n- pnpm ci:local\n\nCloses #48