### PR TITLE
fix: keep replay detail tabs from resetting to Overview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1984,7 +1984,6 @@ function App() {
           hidden={activeWorkspaceTab !== "analysis"}
         >
           <EntityDetailPanel
-            key={effectiveSelectedEntityId ?? "detail-empty"}
             snapshot={snapshot}
             selectedEntityId={effectiveSelectedEntityId}
             runKnowledgeByRunId={runKnowledgeByRunId}

--- a/src/components/EntityDetailPanel.tsx
+++ b/src/components/EntityDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useDeferredValue, useEffect, useMemo, useState } from "react";
+import { Suspense, lazy, useCallback, useDeferredValue, useEffect, useMemo, useState } from "react";
 import {
   buildDetailPanelModelCached,
   buildRunDiffForSelection,
@@ -192,7 +192,7 @@ export function EntityDetailPanel({
   onClose,
 }: Props) {
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<DetailPanelTab>("overview");
+  const [activeTabByEntityId, setActiveTabByEntityId] = useState<Record<string, DetailPanelTab>>({});
   const [runTagFilter, setRunTagFilter] = useState("");
   const [runKnowledgeDraftByRunId, setRunKnowledgeDraftByRunId] = useState<
     Record<string, RunKnowledgeDraft>
@@ -202,6 +202,22 @@ export function EntityDetailPanel({
   );
   const [runComparisonSelection, setRunComparisonSelection] =
     useState<DetailPanelRunComparisonSelection | null>(null);
+  const activeTabEntityKey = selectedEntityId ?? "__empty__";
+  const activeTab = activeTabByEntityId[activeTabEntityKey] ?? "overview";
+  const setActiveTab = useCallback(
+    (nextTab: DetailPanelTab) => {
+      setActiveTabByEntityId((prev) => {
+        if (prev[activeTabEntityKey] === nextTab) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [activeTabEntityKey]: nextTab,
+        };
+      });
+    },
+    [activeTabEntityKey],
+  );
   const deferredActiveTab = useDeferredValue(activeTab);
   const isRunsTabReady = deferredActiveTab === "runs";
   const isDiffTabReady = deferredActiveTab === "diff";


### PR DESCRIPTION
## Summary
- stop remounting `EntityDetailPanel` on replay event/entity changes by removing the volatile `key` prop
- store entity detail tab selection per selected entity id so replay updates do not force a tab reset
- keep existing default behavior (`Overview`) for first-time entities while preserving current tab for active replay entity

## Testing
- pnpm ci:local
- playwright-cli replay verification: selected `Runs` tab remains selected after `eventId` changes in replay URL

Closes #112
