### PR TITLE
feat(minimap): add collapse/expand toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1262,6 +1262,36 @@ body {
   stroke-dasharray: 10 8;
 }
 
+.camera-minimap-toggle {
+  background: rgba(100, 200, 255, 0.15);
+  border: 1px solid rgba(150, 226, 255, 0.35);
+  border-radius: 4px;
+  color: #b5e3f2;
+  font-size: 0.8rem;
+  font-weight: bold;
+  width: 22px;
+  height: 22px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 150ms ease;
+}
+
+.camera-minimap-toggle:hover {
+  background: rgba(100, 200, 255, 0.3);
+}
+
+.camera-minimap.collapsed {
+  width: auto;
+  padding: 6px 8px;
+}
+
+.camera-minimap.collapsed header {
+  gap: 6px;
+}
+
 .focus-fog-layer {
   position: absolute;
   inset: 0;

--- a/src/components/OfficeStage.tsx
+++ b/src/components/OfficeStage.tsx
@@ -427,6 +427,7 @@ export function OfficeStage({
     followSelected: false,
   });
   const [clusteringEnabled, setClusteringEnabled] = useState(true);
+  const [minimapCollapsed, setMinimapCollapsed] = useState(false);
   const [expandedClusterIds, setExpandedClusterIds] = useState<string[]>([]);
   const [pinnedBubbleEntityIds, setPinnedBubbleEntityIds] = useState<string[]>(() =>
     loadBubbleEntityIds(BUBBLE_PINNED_STORAGE_KEY),
@@ -1331,52 +1332,62 @@ export function OfficeStage({
         </span>
       </div>
 
-      <aside className="camera-minimap">
+      <aside className={`camera-minimap${minimapCollapsed ? " collapsed" : ""}`}>
         <header>
           <strong>Minimap</strong>
-          <span>Tap to center</span>
+          {!minimapCollapsed && <span>Tap to center</span>}
+          <button
+            type="button"
+            className="camera-minimap-toggle"
+            onClick={() => setMinimapCollapsed((prev) => !prev)}
+            aria-label={minimapCollapsed ? "Expand minimap" : "Collapse minimap"}
+          >
+            {minimapCollapsed ? "+" : "-"}
+          </button>
         </header>
-        <button
-          type="button"
-          className="camera-minimap-surface"
-          onClick={(event) => {
-            const bounds = event.currentTarget.getBoundingClientRect();
-            if (bounds.width <= 0 || bounds.height <= 0) {
-              return;
-            }
-            const normalizedX = clamp((event.clientX - bounds.left) / bounds.width, 0, 1);
-            const normalizedY = clamp((event.clientY - bounds.top) / bounds.height, 0, 1);
-            centerCameraOnPoint(normalizedX * STAGE_WIDTH, normalizedY * STAGE_HEIGHT);
-          }}
-        >
-          <svg viewBox={`0 0 ${STAGE_WIDTH} ${STAGE_HEIGHT}`} preserveAspectRatio="none" aria-hidden>
-            {rooms.map((room) => (
+        {!minimapCollapsed && (
+          <button
+            type="button"
+            className="camera-minimap-surface"
+            onClick={(event) => {
+              const bounds = event.currentTarget.getBoundingClientRect();
+              if (bounds.width <= 0 || bounds.height <= 0) {
+                return;
+              }
+              const normalizedX = clamp((event.clientX - bounds.left) / bounds.width, 0, 1);
+              const normalizedY = clamp((event.clientY - bounds.top) / bounds.height, 0, 1);
+              centerCameraOnPoint(normalizedX * STAGE_WIDTH, normalizedY * STAGE_HEIGHT);
+            }}
+          >
+            <svg viewBox={`0 0 ${STAGE_WIDTH} ${STAGE_HEIGHT}`} preserveAspectRatio="none" aria-hidden>
+              {rooms.map((room) => (
+                <rect
+                  key={`mini:${room.id}`}
+                  x={room.x}
+                  y={room.y}
+                  width={room.width}
+                  height={room.height}
+                  className="camera-minimap-room"
+                />
+              ))}
+              {selectedPlacement ? (
+                <circle
+                  cx={selectedPlacement.x}
+                  cy={selectedPlacement.y}
+                  r={12}
+                  className="camera-minimap-selected"
+                />
+              ) : null}
               <rect
-                key={`mini:${room.id}`}
-                x={room.x}
-                y={room.y}
-                width={room.width}
-                height={room.height}
-                className="camera-minimap-room"
+                x={viewportBox.x}
+                y={viewportBox.y}
+                width={viewportBox.width}
+                height={viewportBox.height}
+                className="camera-minimap-viewport"
               />
-            ))}
-            {selectedPlacement ? (
-              <circle
-                cx={selectedPlacement.x}
-                cy={selectedPlacement.y}
-                r={12}
-                className="camera-minimap-selected"
-              />
-            ) : null}
-            <rect
-              x={viewportBox.x}
-              y={viewportBox.y}
-              width={viewportBox.width}
-              height={viewportBox.height}
-              className="camera-minimap-viewport"
-            />
-          </svg>
-        </button>
+            </svg>
+          </button>
+        )}
       </aside>
 
       <div


### PR DESCRIPTION
## Summary
- Add a collapse/expand button to the Minimap panel so users can hide it when it obstructs room content

## Problem
- Minimap panel at `right: 12px; top: 12px` overlays Stage content
- Spawn Lab and other rooms may be partially obscured by the Minimap

## Solution
- Added `minimapCollapsed` state and toggle button (+ / -)
- When collapsed: shows only 'Minimap' label and expand button
- When expanded: full minimap with room outlines and viewport indicator
- CSS styling for collapsed state and toggle button

## Changes
| File | Description |
|------|-------------|
| `src/components/OfficeStage.tsx` | Add collapse state and toggle button JSX |
| `src/App.css` | Add `.camera-minimap.collapsed` and toggle button styles |

## Testing
- [x] `pnpm lint` - passes
- [x] `pnpm test` - 150 tests pass
- [x] `pnpm ci:local` - all checks pass
- [x] Manual verification with Playwright - collapse/expand works

Closes #122