### PR TITLE
feat(room): improve empty room visual and status chip readability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1467,6 +1467,25 @@ body {
     0 0 0 1px rgba(255, 124, 124, 0.18);
 }
 
+.office-room.room-empty {
+  opacity: 0.55;
+  border-style: dashed;
+  border-color: rgba(180, 220, 235, 0.35);
+  background: rgba(20, 45, 60, 0.25);
+}
+
+.office-room.room-empty .occupancy-heat {
+  display: none;
+}
+
+.office-room.room-empty header {
+  color: rgba(180, 210, 220, 0.7);
+}
+
+.office-room.room-empty .zone-debug {
+  opacity: 0.6;
+}
+
 .office-room header {
   position: absolute;
   left: 10px;
@@ -1498,22 +1517,47 @@ body {
 }
 
 .zone-debug span {
-  padding: 2px 7px;
+  padding: 3px 8px;
   border-radius: 999px;
-  font-size: 0.66rem;
-  color: rgba(217, 247, 255, 0.92);
-  border: 1px solid rgba(186, 236, 255, 0.32);
-  background: rgba(6, 39, 55, 0.38);
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: rgba(230, 252, 255, 0.95);
+  border: 1px solid rgba(186, 236, 255, 0.45);
+  background: rgba(6, 39, 55, 0.65);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 .zone-debug.has-overflow span {
-  border-color: rgba(255, 203, 120, 0.45);
-  color: rgba(255, 239, 196, 0.95);
+  border-color: rgba(255, 190, 90, 0.7);
+  color: rgba(255, 245, 210, 1);
+  background: rgba(80, 50, 10, 0.7);
+  font-weight: 600;
 }
 
 .zone-debug.has-collision span {
-  border-color: rgba(255, 162, 162, 0.46);
-  color: rgba(255, 222, 222, 0.94);
+  border-color: rgba(255, 140, 140, 0.7);
+  color: rgba(255, 235, 235, 1);
+  background: rgba(80, 20, 20, 0.7);
+  font-weight: 600;
+}
+
+.zone-debug span.saturation-high {
+  border-color: rgba(255, 120, 120, 0.75);
+  color: #fff;
+  background: rgba(180, 50, 50, 0.75);
+  font-weight: 700;
+}
+
+.zone-debug span.saturation-medium {
+  border-color: rgba(255, 200, 100, 0.6);
+  color: rgba(255, 245, 220, 1);
+  background: rgba(100, 70, 20, 0.6);
+}
+
+.zone-debug span.saturation-low {
+  border-color: rgba(140, 220, 180, 0.5);
+  color: rgba(220, 255, 240, 0.95);
+  background: rgba(20, 70, 50, 0.5);
 }
 
 .office-lines {

--- a/src/components/OfficeStage.tsx
+++ b/src/components/OfficeStage.tsx
@@ -1737,10 +1737,11 @@ export function OfficeStage({
         const occupancyPercent = Math.round(occupancyRatio * 100);
         const occupancyHeatLevel =
           occupancyRatio >= 1 ? "high" : occupancyRatio >= 0.7 ? "medium" : "low";
+        const isEmpty = debug ? debug.assigned === 0 : true;
         return (
           <section
             key={room.id}
-            className={`office-room heat-${occupancyHeatLevel}`}
+            className={`office-room heat-${occupancyHeatLevel}${isEmpty ? " room-empty" : ""}`}
             style={{
               left: room.x,
               top: room.y,
@@ -1765,7 +1766,7 @@ export function OfficeStage({
                 </span>
                 <span>occ {debug.utilizationPct || occupancyPercent}%</span>
                 <span>target {debug.targeted}</span>
-                <span>{debug.saturation}</span>
+                <span className={`saturation-${debug.saturation}`}>{debug.saturation}</span>
                 {debug.collisionPairs > 0 ? <span>coll {debug.collisionPairs}</span> : null}
                 {debug.overflowOut > 0 ? <span>out +{debug.overflowOut}</span> : null}
                 {debug.overflowIn > 0 ? <span>in +{debug.overflowIn}</span> : null}


### PR DESCRIPTION
## Summary

- **Empty rooms** now have reduced visual emphasis (dashed border, lower opacity) to avoid wasting screen real estate
- **Status chips** (zone-debug) now have improved readability with larger fonts, better contrast, and text shadows
- **Saturation indicators** use color-coded styling (red=high, amber=medium, green=low)

## Changes

### Empty Room Visual (#124)
- Add `room-empty` class with opacity 0.55 and dashed border
- Hide occupancy heat overlay for empty rooms
- Dim header text for empty rooms

### Status Chip Readability (#125)
- Font size: 0.66rem → 0.72rem
- Added font-weight 500 and text-shadow
- Background opacity increased from 0.38 to 0.65
- Border opacity increased for better definition

### Saturation State Styling
- `saturation-high`: Red background, bold white text
- `saturation-medium`: Amber background
- `saturation-low`: Green background

### Overflow/Collision States
- Increased background opacity
- Added font-weight 600 for urgency

## Testing

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (150 tests)

## Visual Impact

| State | Before | After |
|-------|--------|-------|
| Empty room | Same as occupied | Dashed border, 55% opacity |
| Status chips | 0.66rem, faint | 0.72rem, bold with shadow |
| High saturation | Plain text | Red badge, bold |

Closes #124
Closes #125