### PR TITLE
[UI-03] Datapad 호버 툴팁 추가

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1756,6 +1756,123 @@ body {
   }
 }
 
+.entity-datapad {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 220px;
+  background: rgba(0, 0, 0, 0.95);
+  border: 1px solid #00f3ff;
+  backdrop-filter: blur(8px);
+  padding: 10px;
+  z-index: 9999;
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - 8px),
+    calc(100% - 8px) 100%,
+    0 100%
+  );
+  animation: datapad-in 100ms ease-out;
+  pointer-events: none;
+}
+
+@keyframes datapad-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) scale(1);
+  }
+}
+
+.datapad-header {
+  font-family: "JetBrains Mono", "Space Grotesk", monospace;
+  font-size: 12px;
+  font-weight: 700;
+  color: #00f3ff;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid rgba(0, 243, 255, 0.2);
+}
+
+.datapad-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 3px 0;
+  font-size: 11px;
+}
+
+.datapad-label {
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.datapad-value {
+  color: #e2e8f0;
+  font-family: "JetBrains Mono", monospace;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.datapad-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.datapad-status-active {
+  color: #00f3ff;
+}
+
+.datapad-status-idle {
+  color: #64748b;
+}
+
+.datapad-status-error {
+  color: #ff2a6d;
+}
+
+.datapad-status-ok {
+  color: #05d5fa;
+}
+
+.datapad-status-offline {
+  color: #475569;
+}
+
+.datapad-parent {
+  color: #94a3b8;
+  font-size: 10px;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.datapad-bubble {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(0, 243, 255, 0.15);
+  font-style: italic;
+  font-size: 10px;
+  color: #94a3b8;
+  line-height: 1.4;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
 .entity-cluster {
   position: absolute;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
## Summary

Entity 호버 시 상세 정보를 보여주는 "Datapad" 스타일 툴팁 추가. 기존 Detail Panel 대비 빠른 정보 접근 제공.

## Changes

### EntityDatapad Component
- 새 컴포넌트: 엔티티 상세 정보 표시
- 콘텐츠: 이름, 상태(dot indicator), 지속시간/마지막 활동 시간
- Subagent의 경우 parent agent 표시
- bubble/task 텍스트 표시 (2줄 clamp)

### Hover State Management
- `hoveredEntityId` 상태 추가
- EntityTokenView에 `onMouseEnter`/`onMouseLeave` 핸들러

### CSS Styling
- Glassmorphism 효과 (`backdrop-filter: blur(8px)`)
- Cyberpunk clip-path 코너 컷
- Fade-in 애니메이션 (100ms)
- 상태별 색상 (active=#00F3FF, error=#FF2A6D, idle=#64748B)

## Verification
- [x] `pnpm lint` 통과
- [x] `pnpm test` 통과 (141 tests)
- [x] `pnpm build` 통과

## Related Issues
Closes #132
Part of #129 (UI 톤앤매너 통일)