### PR TITLE
[UI-04] Agent/Subagent 시각적 계층 구분

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1744,6 +1744,48 @@ body {
   opacity: 0.5;
 }
 
+.entity-token.agent {
+  width: 130px;
+  height: 32px;
+  border-width: 1.5px;
+  border-color: rgba(0, 243, 255, 0.25);
+  z-index: 20;
+}
+
+.entity-token.agent .chip-label {
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.entity-token.agent .chip-status {
+  font-size: 10px;
+}
+
+.entity-token.agent .chip-status-bar {
+  width: 4px;
+}
+
+.entity-token.subagent {
+  width: 105px;
+  height: 24px;
+  opacity: 0.88;
+  border-width: 1px;
+  z-index: 10;
+}
+
+.entity-token.subagent .chip-label {
+  font-weight: 500;
+  font-size: 10px;
+}
+
+.entity-token.subagent .chip-status {
+  font-size: 8px;
+}
+
+.entity-token.subagent .chip-status-bar {
+  width: 2px;
+}
+
 @keyframes chip-glitch {
   0%, 100% {
     border-color: rgba(255, 42, 109, 0.35);
@@ -1939,17 +1981,36 @@ body {
 }
 
 /* LOD responsive chip sizing */
-.office-stage-wrap.lod-distant .entity-token {
-  width: 80px;
-  height: 22px;
+.office-stage-wrap.lod-distant .entity-token.agent {
+  width: 90px;
+  height: 24px;
+}
+
+.office-stage-wrap.lod-distant .entity-token.subagent {
+  width: 70px;
+  height: 18px;
 }
 
 .office-stage-wrap.lod-distant .entity-token .chip-label {
   font-size: 9px;
 }
 
+.office-stage-wrap.lod-distant .entity-token.subagent .chip-label {
+  font-size: 8px;
+}
+
 .office-stage-wrap.lod-distant .entity-token .chip-status {
   display: none;
+}
+
+.office-stage-wrap.lod-mid .entity-token.agent {
+  width: 120px;
+  height: 30px;
+}
+
+.office-stage-wrap.lod-mid .entity-token.subagent {
+  width: 95px;
+  height: 22px;
 }
 
 .office-stage-wrap.lod-mid .entity-token .chip-status {
@@ -1958,6 +2019,10 @@ body {
 
 .office-stage-wrap.lod-mid .entity-token .chip-label {
   font-size: 10px;
+}
+
+.office-stage-wrap.lod-mid .entity-token.subagent .chip-label {
+  font-size: 9px;
 }
 
 .office-stage-wrap.lod-distant .bubble-lane-overlay {


### PR DESCRIPTION
## Summary

Agent(Commander)와 Subagent(Worker)를 시각적으로 명확히 구분하여 운영자가 계층 구조를 즉시 파악할 수 있도록 함.

## Changes

### Agent (The Commander)
- Size: 130px × 32px (더 크고 눈에 띄게)
- Border: 1.5px, rgba(0, 243, 255, 0.25)
- Font weight: 700 (bold)
- Status bar: 4px width
- z-index: 20 (항상 위에 렌더링)

### Subagent (The Worker)
- Size: 105px × 24px (더 작고 컴팩트)
- Opacity: 0.88 (약간 투명)
- Border: 1px
- Font weight: 500
- Status bar: 2px width
- z-index: 10 (Agent 아래 렌더링)

### LOD Responsive
- distant view: Agent 90x24px, Subagent 70x18px
- mid view: Agent 120x30px, Subagent 95x22px
- 모든 줌 레벨에서 계층 구분 유지

## Verification
- [x] `pnpm lint` 통과
- [x] `pnpm test` 통과 (141 tests)
- [x] `pnpm build` 통과

## Related Issues
Closes #133
Part of #129 (UI 톤앤매너 통일)