### PR TITLE
[UI-05] 고밀도 모드 레이아웃 (10+ entities)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1786,6 +1786,63 @@ body {
   width: 2px;
 }
 
+.entity-token.density-compact.subagent {
+  width: 85px;
+  height: 20px;
+}
+
+.entity-token.density-compact.subagent .chip-label {
+  font-size: 9px;
+}
+
+.entity-token.density-compact.subagent .chip-status {
+  display: none;
+}
+
+.entity-token.density-dense.subagent {
+  width: 50px;
+  height: 8px;
+  overflow: hidden;
+  transition:
+    width 150ms ease,
+    height 150ms ease,
+    z-index 0ms;
+}
+
+.entity-token.density-dense.subagent .chip-content {
+  display: none;
+}
+
+.entity-token.density-dense.subagent .chip-status-bar {
+  width: 100%;
+  border-radius: 2px;
+}
+
+.entity-token.density-dense.subagent:hover {
+  width: 100px;
+  height: 24px;
+  z-index: 100;
+}
+
+.entity-token.density-dense.subagent:hover .chip-content {
+  display: flex;
+}
+
+.entity-token.density-dense.subagent:hover .chip-status-bar {
+  width: 3px;
+  border-radius: 1px 0 0 1px;
+}
+
+.entity-token.density-compact.agent,
+.entity-token.density-dense.agent {
+  width: 110px;
+  height: 28px;
+}
+
+.entity-token.density-dense.agent .chip-status {
+  display: none;
+}
+
 @keyframes chip-glitch {
   0%, 100% {
     border-color: rgba(255, 42, 109, 0.35);


### PR DESCRIPTION
## Summary

Room에 10개 이상의 Entity가 있을 때 자동으로 고밀도 모드로 전환하여 시각적 혼잡을 방지.

## Changes

### Density Mode Logic (OfficeStage.tsx)
- `roomDensityMode` Map 계산: room별 entity count 기반
- `placementByEntityId` Map으로 entity → room 매핑
- EntityTokenView에 `densityMode` prop 전달

### Density Thresholds
| Mode | Entity Count | Behavior |
|------|--------------|----------|
| Standard | 1-9 | 기본 chip 크기 |
| Compact | 10-25 | Subagent 축소 (85×20px) |
| Dense | 26+ | Subagent → 상태 바 (50×8px) |

### Compact Mode
- Subagent: 85×20px, font-size 9px
- Status label 숨김

### Dense Mode  
- Subagent: 50×8px, 텍스트 숨김, 상태 바만 표시
- 호버 시 확장: 100×24px, z-index 100
- Smooth transition (150ms)
- Agent는 모든 밀도 모드에서 가시성 유지 (110×28px)

## Verification
- [x] `pnpm lint` 통과
- [x] `pnpm test` 통과 (141 tests)
- [x] `pnpm build` 통과

## Related Issues
Closes #134
Completes #129 (UI 톤앤매너 통일)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 엔티티 토큰의 밀도별 표시 모드 추가 (표준/압축/밀집)
  * 밀도 설정에 따라 레이블과 상태 정보의 표시 여부 자동 조정
  * 밀집 모드에서 마우스 호버 시 추가 콘텐츠 표시
  * 각 밀도 모드에 최적화된 크기 및 여백 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->