### PR TITLE
fix(#144): add setTimeout cleanup in CommandPalette

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -70,10 +70,11 @@ export function CommandPalette({
     orderedCommands.length === 0 ? 0 : Math.min(activeIndex, orderedCommands.length - 1);
 
   useEffect(() => {
-    window.setTimeout(() => {
+    const timer = window.setTimeout(() => {
       inputRef.current?.focus();
       inputRef.current?.select();
     }, 0);
+    return () => window.clearTimeout(timer);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Resolves #144

## Changes
- Store setTimeout return value in a variable
- Add cleanup function to clear timeout on component unmount
- Prevents potential memory leak and stale callback execution on unmounted component

## Testing
- [x] Unit tests pass (141 tests)
- [x] ESLint passes
- [x] Build succeeds

## Before
```typescript
useEffect(() => {
  window.setTimeout(() => {
    inputRef.current?.focus();
    inputRef.current?.select();
  }, 0);
}, []);
```

## After
```typescript
useEffect(() => {
  const timer = window.setTimeout(() => {
    inputRef.current?.focus();
    inputRef.current?.select();
  }, 0);
  return () => window.clearTimeout(timer);
}, []);
```