### PR TITLE
fix(#147): add logging to empty catch blocks

### DIFF
--- a/server/snapshot-store.ts
+++ b/server/snapshot-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { gunzip, gzip } from "node:zlib";
 import { isOfficeSnapshot, type OfficeSnapshot } from "./office-types";
+import { logStructuredEvent } from "./api-observability";
 
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
@@ -375,6 +376,7 @@ export class OfficeSnapshotStore {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         this.indexCache = normalizeIndexFile(null);
       } else {
+        logStructuredEvent({ level: "warn", event: "snapshot-store.index.read.error", extra: { path: this.indexPath, error: String(error) } });
         this.indexCache = normalizeIndexFile(null);
       }
     }

--- a/server/transcript-tailer.ts
+++ b/server/transcript-tailer.ts
@@ -177,6 +177,7 @@ function processTranscriptLine(line: string, seq: number, state: TranscriptTailS
   try {
     parsed = JSON.parse(line) as unknown;
   } catch {
+    // Skip malformed lines - expected during streaming or partial writes.
     return;
   }
 

--- a/src/lib/entity-batch-actions.ts
+++ b/src/lib/entity-batch-actions.ts
@@ -61,7 +61,10 @@ export function loadBatchActionState(): BatchActionState {
       return createEmptyBatchActionState();
     }
     return normalizeBatchActionState(JSON.parse(raw));
-  } catch {
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[entity-batch-actions] load error:", error);
+    }
     return createEmptyBatchActionState();
   }
 }
@@ -72,8 +75,10 @@ export function persistBatchActionState(state: BatchActionState) {
   }
   try {
     window.localStorage.setItem(ENTITY_BATCH_ACTIONS_STORAGE_KEY, JSON.stringify(state));
-  } catch {
-    // Ignore localStorage persistence errors in restricted browser modes.
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[entity-batch-actions] persist error:", error);
+    }
   }
 }
 

--- a/src/lib/run-comparison-store.ts
+++ b/src/lib/run-comparison-store.ts
@@ -48,7 +48,10 @@ export function parseSavedRunComparisons(raw: string | null): SavedRunComparison
       .map((item) => normalizeSavedRunComparison(item))
       .filter((item): item is SavedRunComparison => item !== null)
       .sort((left, right) => right.createdAt - left.createdAt);
-  } catch {
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[run-comparison-store] parse error:", error);
+    }
     return [];
   }
 }
@@ -63,7 +66,10 @@ export function loadSavedRunComparisons(): SavedRunComparison[] {
   }
   try {
     return parseSavedRunComparisons(window.localStorage.getItem(RUN_COMPARISON_STORAGE_KEY));
-  } catch {
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[run-comparison-store] load error:", error);
+    }
     return [];
   }
 }
@@ -74,8 +80,10 @@ export function persistSavedRunComparisons(saved: SavedRunComparison[]) {
   }
   try {
     window.localStorage.setItem(RUN_COMPARISON_STORAGE_KEY, JSON.stringify(saved));
-  } catch {
-    // Ignore localStorage persistence errors in restricted browser modes.
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[run-comparison-store] persist error:", error);
+    }
   }
 }
 

--- a/src/lib/run-notes-store.ts
+++ b/src/lib/run-notes-store.ts
@@ -100,7 +100,10 @@ export function parseRunKnowledgeEntries(raw: string | null): RunKnowledgeEntry[
       }
     }
     return [...dedupedByRun.values()].sort((left, right) => right.updatedAt - left.updatedAt);
-  } catch {
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[run-notes-store] parse error:", error);
+    }
     return [];
   }
 }
@@ -111,7 +114,10 @@ export function loadRunKnowledgeEntries(): RunKnowledgeEntry[] {
   }
   try {
     return parseRunKnowledgeEntries(window.localStorage.getItem(RUN_KNOWLEDGE_STORAGE_KEY));
-  } catch {
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[run-notes-store] load error:", error);
+    }
     return [];
   }
 }
@@ -122,8 +128,10 @@ export function persistRunKnowledgeEntries(entries: RunKnowledgeEntry[]): void {
   }
   try {
     window.localStorage.setItem(RUN_KNOWLEDGE_STORAGE_KEY, JSON.stringify(entries));
-  } catch {
-    // Ignore localStorage persistence errors in restricted browser modes.
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[run-notes-store] persist error:", error);
+    }
   }
 }
 

--- a/src/lib/workspace-layout.ts
+++ b/src/lib/workspace-layout.ts
@@ -52,7 +52,10 @@ export function parseWorkspaceLayout(raw: string | null): WorkspaceLayoutState {
   try {
     const parsed: unknown = JSON.parse(raw);
     return normalizeWorkspaceLayout(parsed);
-  } catch {
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[workspace-layout] parse error:", error);
+    }
     return DEFAULT_WORKSPACE_LAYOUT_STATE;
   }
 }
@@ -63,7 +66,10 @@ export function loadWorkspaceLayoutState(): WorkspaceLayoutState {
   }
   try {
     return parseWorkspaceLayout(window.localStorage.getItem(WORKSPACE_LAYOUT_STATE_KEY));
-  } catch {
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[workspace-layout] load state error:", error);
+    }
     return DEFAULT_WORKSPACE_LAYOUT_STATE;
   }
 }
@@ -74,8 +80,10 @@ export function persistWorkspaceLayoutState(layout: WorkspaceLayoutState): void 
   }
   try {
     window.localStorage.setItem(WORKSPACE_LAYOUT_STATE_KEY, JSON.stringify(layout));
-  } catch {
-    // Ignore localStorage persistence errors in restricted browser modes.
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[workspace-layout] persist state error:", error);
+    }
   }
 }
 
@@ -89,7 +97,10 @@ export function loadWorkspaceLayoutSnapshot(): WorkspaceLayoutState | null {
       return null;
     }
     return parseWorkspaceLayout(raw);
-  } catch {
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[workspace-layout] load snapshot error:", error);
+    }
     return null;
   }
 }
@@ -100,8 +111,10 @@ export function persistWorkspaceLayoutSnapshot(layout: WorkspaceLayoutState): vo
   }
   try {
     window.localStorage.setItem(WORKSPACE_LAYOUT_SNAPSHOT_KEY, JSON.stringify(layout));
-  } catch {
-    // Ignore localStorage persistence errors in restricted browser modes.
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn("[workspace-layout] persist snapshot error:", error);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `logStructuredEvent` logging in server-side code for fs/index file errors
- Add `import.meta.env.DEV` conditional `console.warn` for client-side localStorage errors
- Add explanatory comment for intentionally ignored JSON parse errors in transcript-tailer

Closes #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 파일 시스템 및 데이터 저장 작업의 오류 처리에 진단 로깅을 추가했습니다. 내부 I/O 작업 실패 시 상세한 로그 정보를 기록하여 시스템 관찰 가능성을 개선했습니다. 기존 기능 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->