### PR TITLE
fix(a11y): add loading spinner with ARIA busy state (#154)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4394,7 +4394,31 @@ body {
   color: #ffd39f;
 }
 
+@keyframes loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  margin: 24px auto 0;
+  border: 3px solid var(--line);
+  border-top-color: var(--good);
+  border-radius: 50%;
+  animation: loading-spin 0.8s linear infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .loading-spinner {
+    animation: none;
+    border-top-color: var(--line);
+    background: conic-gradient(from 0deg, var(--good) 0%, var(--good) 25%, transparent 25%);
+    -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 3px), black calc(100% - 3px));
+    mask: radial-gradient(farthest-side, transparent calc(100% - 3px), black calc(100% - 3px));
+    border: none;
+  }
   .hero-bar,
   .run-link,
   .entity-token,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1431,8 +1431,9 @@ function App() {
   if (!snapshot) {
     return (
       <main className="app-shell">
-        <div className="loading-view">
+        <div className="loading-view" role="status" aria-busy="true" aria-live="polite">
           <h1>openClawOffice</h1>
+          <div className="loading-spinner" aria-hidden="true" />
           <p>Loading office state stream...</p>
           {error ? <p className="error-text">{error}</p> : null}
           {recoveryMessage ? <p className="recovery-text">{recoveryMessage}</p> : null}


### PR DESCRIPTION
## Summary
Resolves #154

Adds a visual loading indicator (CSS-animated spinner) to the initial load screen with proper accessibility attributes.

## Changes
- Add `@keyframes loading-spin` animation and `.loading-spinner` styles in App.css
- Add `role="status"`, `aria-busy="true"`, `aria-live="polite"` to loading view for screen reader support
- Add spinner div with `aria-hidden="true"` (decorative element)
- Respect `prefers-reduced-motion`: shows static conic-gradient indicator instead of animation

## Testing
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (141 tests)
- [x] `pnpm build` passes
- [x] Spinner visible during initial load (before snapshot arrives)

## Acceptance Criteria
- [x] Visual loading indicator (spinner) displayed during load
- [x] ARIA attributes added for screen reader support
- [x] Animation respects `prefers-reduced-motion` media query