### PR TITLE
feat(ux): add empty state UI when no agents exist (#155)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4410,6 +4410,41 @@ body {
   animation: loading-spin 0.8s linear infinite;
 }
 
+.empty-state {
+  max-width: 480px;
+  margin: 60px auto;
+  padding: 32px;
+  text-align: center;
+  border: 1px dashed var(--line);
+  border-radius: 12px;
+  background: rgba(9, 31, 45, 0.5);
+}
+
+.empty-state h2 {
+  margin: 0 0 16px;
+  font-size: 1.25rem;
+  color: var(--text);
+}
+
+.empty-state p {
+  margin: 0 0 12px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.empty-state code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85em;
+  color: var(--text);
+}
+
+.empty-state-hint {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .loading-spinner {
     animation: none;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1447,6 +1447,7 @@ function App() {
   const running = subagents.filter((entity) => entity.status === "active").length;
   const failed = subagents.filter((entity) => entity.status === "error").length;
   const diagnostics = snapshot.diagnostics.slice(0, 2);
+  const isEmptyOffice = agents.length === 0 && subagents.length === 0;
   const highlightRunId = activeEvent?.runId ?? (timelineFilters.runId.trim() || null);
   const timelineFilterAgentId = timelineFilters.agentId.trim();
   const highlightAgentId =
@@ -1492,6 +1493,19 @@ function App() {
         <section className="recovery-banner" role="status" aria-live="polite">
           <strong>Recovery Mode</strong>
           <p>{recoveryMessage}</p>
+        </section>
+      ) : null}
+
+      {isEmptyOffice ? (
+        <section className="empty-state" role="status">
+          <h2>No agents detected</h2>
+          <p>
+            openClawOffice monitors agents from your OpenClaw runtime directory.
+            Start an agent session or verify that <code>{snapshot.source.stateDir}</code> contains agent data.
+          </p>
+          <p className="empty-state-hint">
+            See <code>README.md</code> &rarr; Troubleshooting for setup instructions.
+          </p>
         </section>
       ) : null}
 


### PR DESCRIPTION
## Summary
Resolves #155

Adds a friendly empty state UI when no agents or subagents are detected, guiding users on how to get started.

## Changes
- Add `isEmptyOffice` check after entity filtering
- Display empty state section with guidance message
- Show state directory path from `snapshot.source.stateDir`
- Add `.empty-state` styles with dashed border and centered layout

## Testing
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (141 tests)
- [x] `pnpm build` passes

## Acceptance Criteria
- [x] Empty state shows when `agents.length === 0 && subagents.length === 0`
- [x] Displays state directory path
- [x] Does NOT show during loading (only after snapshot loads)
- [x] Consistent styling with existing project theme