### PR TITLE
fix(a11y): add skip-to-content link for keyboard navigation (#157)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,6 +41,28 @@ body {
   overflow-x: clip;
 }
 
+.skip-link {
+  position: fixed;
+  top: -100%;
+  left: 16px;
+  z-index: 10000;
+  padding: 10px 18px;
+  background: var(--bg-a);
+  color: var(--text);
+  border: 2px solid var(--good);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: top var(--motion-fast);
+}
+
+.skip-link:focus {
+  top: 16px;
+  outline: 2px solid var(--good);
+  outline-offset: 2px;
+}
+
 .app-shell {
   display: flex;
   flex-direction: column;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1430,15 +1430,20 @@ function App() {
 
   if (!snapshot) {
     return (
-      <main className="app-shell">
-        <div className="loading-view" role="status" aria-busy="true" aria-live="polite">
-          <h1>openClawOffice</h1>
-          <div className="loading-spinner" aria-hidden="true" />
-          <p>Loading office state stream...</p>
-          {error ? <p className="error-text">{error}</p> : null}
-          {recoveryMessage ? <p className="recovery-text">{recoveryMessage}</p> : null}
-        </div>
-      </main>
+      <>
+        <a href="#main-content" className="skip-link">
+          Skip to main content
+        </a>
+        <main className="app-shell" id="main-content">
+          <div className="loading-view" role="status" aria-busy="true" aria-live="polite">
+            <h1>openClawOffice</h1>
+            <div className="loading-spinner" aria-hidden="true" />
+            <p>Loading office state stream...</p>
+            {error ? <p className="error-text">{error}</p> : null}
+            {recoveryMessage ? <p className="recovery-text">{recoveryMessage}</p> : null}
+          </div>
+        </main>
+      </>
     );
   }
 
@@ -1474,9 +1479,13 @@ function App() {
         : "has-double-docked";
 
   return (
-    <main className="app-shell">
-      <GlobalStatusBar
-        connected={connected}
+    <>
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
+      <main className="app-shell" id="main-content">
+        <GlobalStatusBar
+          connected={connected}
         liveSource={liveSource}
         agents={agents.length}
         subagents={subagents.length}
@@ -2184,6 +2193,7 @@ function App() {
         </div>
       ) : null}
     </main>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
Resolves #157

Adds a "Skip to main content" link for keyboard and screen reader users to bypass navigation.

## Changes
- Add `.skip-link` positioned off-screen, revealed on focus
- Add `id="main-content"` to both `<main>` elements (loading and main views)
- Wrap both returns in fragments to accommodate skip link

## Testing
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (141 tests)
- [x] `pnpm build` passes
- [x] Tab on page load shows "Skip to main content" link

## Acceptance Criteria
- [x] Skip link hidden by default
- [x] Visible when focused via Tab
- [x] Jumps focus to main content area
- [x] Styled consistently with app theme (green accent)