### PR TITLE
feat(a11y): add focus trap to modal dialogs (#156)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { GlobalStatusBar } from "./components/GlobalStatusBar";
 import { OfficeStage } from "./components/OfficeStage";
 import { SummaryExporter } from "./components/SummaryExporter";
 import { ThroughputDashboard } from "./components/ThroughputDashboard";
+import { useFocusTrap } from "./hooks/useFocusTrap";
 import { useOfficeStream } from "./hooks/useOfficeStream";
 import {
   DEFAULT_ALERT_RULE_PREFERENCES,
@@ -303,6 +304,8 @@ function App() {
     alerts: null,
   });
   const shortcutPlatform = useMemo(() => detectShortcutPlatform(), []);
+  const alertCenterTrapRef = useFocusTrap<HTMLDivElement>(isAlertCenterOpen);
+  const shortcutHelpTrapRef = useFocusTrap<HTMLDivElement>(isShortcutHelpOpen);
 
   const showToast = useCallback((kind: NonNullable<ToastState>["kind"], message: string) => {
     setToast({ kind, message });
@@ -2026,6 +2029,7 @@ function App() {
 
       {isAlertCenterOpen ? (
         <div
+          ref={alertCenterTrapRef}
           className="alert-center-overlay"
           role="presentation"
           onMouseDown={(event) => {
@@ -2074,6 +2078,7 @@ function App() {
 
       {isShortcutHelpOpen ? (
         <div
+          ref={shortcutHelpTrapRef}
           className="shortcut-help-overlay"
           role="presentation"
           onMouseDown={(event) => {

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { filterCommandIds } from "../lib/command-palette";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 export type CommandPaletteEntry = {
   id: string;
@@ -29,6 +30,7 @@ export function CommandPalette({
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const focusTrapRef = useFocusTrap<HTMLDivElement>(true);
 
   const commandById = useMemo(
     () => new Map(commands.map((command) => [command.id, command])),
@@ -125,6 +127,7 @@ export function CommandPalette({
 
   return (
     <div
+      ref={focusTrapRef}
       className="command-palette-overlay"
       role="presentation"
       onMouseDown={(event) => {

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Traps focus within a container when active. Returns focus to trigger on cleanup.
+ */
+export function useFocusTrap<T extends HTMLElement>(active: boolean): RefObject<T | null> {
+  const containerRef = useRef<T | null>(null);
+  const triggerElementRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    triggerElementRef.current = document.activeElement;
+
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusableElements = Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      );
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const isShiftTab = event.shiftKey;
+      const isOnFirstElement = document.activeElement === firstElement;
+      const isOnLastElement = document.activeElement === lastElement;
+
+      if (isShiftTab && isOnFirstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!isShiftTab && isOnLastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    container.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+      if (triggerElementRef.current instanceof HTMLElement) {
+        triggerElementRef.current.focus();
+      }
+    };
+  }, [active]);
+
+  return containerRef;
+}


### PR DESCRIPTION
## Summary
Resolves #156

Adds focus trapping to all modal dialogs, preventing Tab from escaping to background content and restoring focus to the trigger element on close.

## Changes
- Create `src/hooks/useFocusTrap.ts` hook
- Apply focus trap to `CommandPalette` component
- Apply focus trap to `AlertCenter` overlay in App.tsx
- Apply focus trap to `ShortcutHelp` overlay in App.tsx

## Testing
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (141 tests)
- [x] `pnpm build` passes

## Acceptance Criteria
- [x] Tab key cycles within modal only
- [x] Shift+Tab cycles backward within modal
- [x] Focus returns to trigger element on close
- [x] Works for CommandPalette, AlertCenter, ShortcutHelp