### PR TITLE
docs: add OpenClaw Hub documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Web-based visual command center for OpenClaw agents and subagents.
 - Timeline debugger with playback and filtering
 - Command palette with keyboard shortcuts
 - Alert rules engine with notification controls
+- **OpenClaw Hub**: comprehensive project status dashboard with progressive disclosure
 
 ## Quick Start
 
@@ -65,6 +66,7 @@ Zone layout is configured via `public/assets/layout/zone-config.json`. Changes a
 | Shortcut | Action |
 |----------|--------|
 | `⌘/Ctrl + K` | Open command palette |
+| `⌘/Ctrl + H` | Toggle OpenClaw Hub |
 | `⌘/Ctrl + Shift + A` | Open alert center |
 | `Escape` | Close panel / Clear selection |
 | `+` / `-` | Zoom in / out |
@@ -95,6 +97,8 @@ All endpoints are available on the dev server (`127.0.0.1:5179`):
 | `/api/office/snapshot` | GET | Full office state snapshot |
 | `/api/office/stream` | GET | SSE stream for real-time updates |
 | `/api/office/metrics` | GET | Server metrics and diagnostics |
+| `/api/office/openclaw-hub` | GET | OpenClaw project status snapshot |
+| `/api/office/openclaw-hub/doc` | GET | Full document content (`?path=`) |
 
 ### SSE Stream Protocol
 
@@ -141,6 +145,8 @@ Customize room positions, sizes, and routing rules:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENCLAW_STATE_DIR` | `~/.openclaw` | OpenClaw state directory |
+| `OPENCLAW_PROJECT_DIR` | `../openclaw` | OpenClaw project root for Hub dashboard |
+| `OPENCLAW_GATEWAY_PORT` | `18789` | OpenClaw gateway port for health checks |
 | `PORT` | `5179` | Dev server port |
 
 ## Development
@@ -203,6 +209,7 @@ openClawOffice/
 - [Operator Playbook](docs/operator-playbook.md)
 - [Quality Gate](docs/quality-gate.md)
 - [Room Blueprint](docs/room-blueprint.md)
+- [OpenClaw Hub](docs/openclaw-hub.md)
 
 ## License
 

--- a/docs/openclaw-hub.md
+++ b/docs/openclaw-hub.md
@@ -1,0 +1,116 @@
+# OpenClaw Status Hub
+
+The Hub tab provides a comprehensive dashboard for monitoring the state of the sibling `openclaw` project. It collects git status, gateway health, channels, skills, memory, cron jobs, documentation, and changelog data into a single view with progressive disclosure.
+
+## Architecture
+
+```
+openclaw project (../openclaw/)
+  │  git commands + file reads (30s cache)
+  ▼
+server/openclaw-status.ts  →  buildOpenClawHubSnapshot()
+  │
+  ▼
+GET /api/office/openclaw-hub          ← 30s poll from frontend
+GET /api/office/openclaw-hub/doc      ← on-demand full document
+  │
+  ▼
+useOpenClawHub() hook  →  <OpenClawHub /> tab panel
+```
+
+## Progressive Disclosure
+
+| Level | Interaction | Content |
+|-------|------------|---------|
+| **L0** | Glance | Card grid with severity dot and one-line summary |
+| **L1** | Hover | CSS tooltip showing 3-5 detail lines |
+| **L2** | Click | Card expands to reveal full metrics and lists |
+| **L3** | "View Details" | Slide-in panel for doc viewer, changelog deep-dive, etc. |
+
+## Cards
+
+| Card | Severity Rules | Data Source |
+|------|---------------|-------------|
+| **Project** | bad = no package.json; warn = dirty/behind; good = clean | `package.json` + `git status` |
+| **Gateway** | bad = offline; good = reachable | `GET 127.0.0.1:{port}/health` |
+| **Channels** | neutral = 0; good = 1+ | `src/channels/` + `extensions/` |
+| **Skills** | neutral = 0; good = 1+ | `skills/` |
+| **Memory** | neutral = not found; good = found | `src/memory/` |
+| **Cron** | neutral = not found; good = found | `src/cron/` |
+| **Docs** | neutral = 0; good = 1+ | `README.md` + `docs/` |
+| **Changelog** | neutral = 0; good = 1+ | `CHANGELOG.md` |
+
+## API Endpoints
+
+### `GET /api/office/openclaw-hub`
+
+Returns the full `OpenClawHubSnapshot` JSON object containing all collected data. Responses are cached server-side for 30 seconds.
+
+**Response fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `generatedAt` | `number` | Unix timestamp (ms) of snapshot creation |
+| `projectDir` | `string` | Resolved path to the openclaw project |
+| `git` | `object \| null` | Branch, commits behind, last commit, dirty files |
+| `project` | `object \| null` | Name, version, deps/devDeps count, scripts |
+| `gateway` | `object \| null` | Reachable flag, latency, URL, port |
+| `channels` | `array` | Channel name, source directory, file count |
+| `skills` | `array` | Skill name and path |
+| `memory` | `object \| null` | Memory module .ts/.js files |
+| `cron` | `object \| null` | Cron module .ts/.js files |
+| `docs` | `array` | Document path, title, first paragraph, headings, size |
+| `changelog` | `array` | Version, added/fixed/changed counts, highlights |
+| `docker` | `object \| null` | Docker Compose service names |
+| `diagnostics` | `array` | Info/warning/error messages from collection |
+
+### `GET /api/office/openclaw-hub/doc?path=<relativePath>`
+
+Returns the full content of a markdown document within the openclaw project directory. Path traversal is rejected (no `..`, no absolute paths).
+
+**Query parameters:**
+
+| Param | Required | Description |
+|-------|----------|-------------|
+| `path` | Yes | Relative path within the openclaw project (e.g., `README.md`, `docs/guide.md`) |
+
+**Response:** `{ "content": "<full file content>" }`
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENCLAW_PROJECT_DIR` | `../openclaw` (relative to cwd) | Absolute or relative path to the openclaw project root |
+| `OPENCLAW_GATEWAY_PORT` | `18789` | Port number for the openclaw gateway health check |
+
+## Caching Strategy
+
+| Data | TTL | Rationale |
+|------|-----|-----------|
+| Hub snapshot (git, files, docs) | 30 s | File system and git data changes infrequently |
+| Gateway health check | 10 s | Health status should reflect near-real-time state |
+| Frontend polling | 30 s | Matches server cache to avoid redundant recomputation |
+
+## File Structure
+
+```
+server/
+├── openclaw-hub-types.ts     # Shared TypeScript type definitions
+├── openclaw-status.ts        # Server-side data collection and caching
+└── vite-office-plugin.ts     # API route handlers (modified)
+
+src/
+├── lib/openclaw-hub.ts       # Severity resolution, formatting, markdown parsing
+├── hooks/useOpenClawHub.ts   # Polling hook (30s interval)
+└── components/
+    ├── OpenClawHub.tsx        # Main hub container with 8 cards
+    ├── HubDetailPanel.tsx     # Slide-in detail panel (L3)
+    └── HubTooltip.tsx         # CSS tooltip wrapper (L1)
+```
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `⌘/Ctrl + H` | Toggle Hub tab |
+| `Escape` | Close detail panel |

--- a/server/openclaw-hub-types.ts
+++ b/server/openclaw-hub-types.ts
@@ -1,3 +1,4 @@
+/** Git repository status for the openclaw project. */
 export type OpenClawGitStatus = {
   branch: string;
   commitsBehind: number;
@@ -8,6 +9,7 @@ export type OpenClawGitStatus = {
   dirtyFiles: string[];
 };
 
+/** Project metadata extracted from package.json. */
 export type OpenClawProjectMeta = {
   name: string;
   version: string;
@@ -18,6 +20,7 @@ export type OpenClawProjectMeta = {
   nodeEngine?: string;
 };
 
+/** Gateway health-check result (probed at 127.0.0.1:{port}/health). */
 export type OpenClawGatewayStatus = {
   reachable: boolean;
   latencyMs: number | null;
@@ -25,25 +28,30 @@ export type OpenClawGatewayStatus = {
   port: number;
 };
 
+/** A messaging channel discovered under src/channels/ or extensions/. */
 export type OpenClawChannelInfo = {
   name: string;
   sourceDir: string;
   fileCount: number;
 };
 
+/** A skill discovered under the skills/ directory. */
 export type OpenClawSkillInfo = {
   name: string;
   path: string;
 };
 
+/** Memory module file listing from src/memory/. */
 export type OpenClawMemoryInfo = {
   files: string[];
 };
 
+/** Cron module file listing from src/cron/. */
 export type OpenClawCronInfo = {
   files: string[];
 };
 
+/** Summary of a markdown document (first 4 KB parsed for headings). */
 export type OpenClawDocSummary = {
   path: string;
   title: string;
@@ -52,6 +60,7 @@ export type OpenClawDocSummary = {
   sizeBytes: number;
 };
 
+/** Parsed CHANGELOG.md version entry with change counts. */
 export type OpenClawChangelogEntry = {
   version: string;
   addedCount: number;
@@ -60,22 +69,26 @@ export type OpenClawChangelogEntry = {
   highlights: string[];
 };
 
+/** A service parsed from docker-compose.yml. */
 export type OpenClawDockerService = {
   name: string;
   image?: string;
   ports?: string[];
 };
 
+/** Docker Compose configuration summary. */
 export type OpenClawDockerConfig = {
   services: OpenClawDockerService[];
 };
 
+/** Diagnostic message emitted during snapshot collection. */
 export type HubDiagnostic = {
   level: "info" | "warning" | "error";
   code: string;
   message: string;
 };
 
+/** Top-level aggregate snapshot returned by the Hub API. Cached for 30 s. */
 export type OpenClawHubSnapshot = {
   generatedAt: number;
   projectDir: string;

--- a/server/openclaw-status.ts
+++ b/server/openclaw-status.ts
@@ -31,6 +31,7 @@ let cachedSnapshot: OpenClawHubSnapshot | null = null;
 let cachedAt = 0;
 let cachedGateway: { result: OpenClawGatewayStatus; at: number } | null = null;
 
+/** Resolve the openclaw project root. Uses `OPENCLAW_PROJECT_DIR` env var or defaults to `../openclaw`. */
 export function resolveOpenClawProjectDir(): string {
   const fromEnv = process.env.OPENCLAW_PROJECT_DIR?.trim();
   if (fromEnv && !fromEnv.includes("\0")) {
@@ -371,6 +372,12 @@ async function loadChangelog(dir: string): Promise<OpenClawChangelogEntry[]> {
   }
 }
 
+/**
+ * Build a comprehensive snapshot of the openclaw project state.
+ * Collects git status, project metadata, gateway health, channels, skills,
+ * memory, cron, docker, docs, and changelog in parallel. Results are cached
+ * for {@link CACHE_TTL_MS} (30 s).
+ */
 export async function buildOpenClawHubSnapshot(): Promise<OpenClawHubSnapshot> {
   const now = Date.now();
   if (cachedSnapshot && now - cachedAt < CACHE_TTL_MS) {
@@ -456,6 +463,10 @@ export async function buildOpenClawHubSnapshot(): Promise<OpenClawHubSnapshot> {
   return snapshot;
 }
 
+/**
+ * Load the full content of a document within the project directory.
+ * Returns `null` if the path attempts traversal outside the project root.
+ */
 export async function loadFullDocument(dir: string, docPath: string): Promise<string | null> {
   // Security: prevent path traversal
   const normalized = path.normalize(docPath);

--- a/src/components/HubDetailPanel.tsx
+++ b/src/components/HubDetailPanel.tsx
@@ -1,7 +1,13 @@
+/**
+ * Slide-in detail panel for the Hub dashboard (L3 progressive disclosure).
+ * Supports deep-dive into docs, changelog, channels, and skills.
+ * Fetches full document content on demand with AbortController for race-safety.
+ */
 import { useCallback, useEffect, useRef, useState } from "react";
 import { parseMarkdownToSections, type MarkdownSection } from "../lib/openclaw-hub";
 import type { OpenClawChangelogEntry, OpenClawChannelInfo, OpenClawSkillInfo } from "../../server/openclaw-hub-types";
 
+/** Discriminated union for the four detail panel content types. */
 type DetailTarget =
   | { kind: "doc"; path: string; title: string }
   | { kind: "changelog"; entry: OpenClawChangelogEntry }

--- a/src/components/HubTooltip.tsx
+++ b/src/components/HubTooltip.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from "react";
 
 type Props = {
+  /** Newline-separated tooltip text rendered via CSS `::after` pseudo-element. */
   tip: string;
   children: ReactNode;
 };
 
+/** CSS-driven tooltip wrapper. Renders children with a `data-tip` attribute for hover display. */
 export function HubTooltip({ tip, children }: Props) {
   return (
     <span className="hub-tooltip" data-tip={tip}>

--- a/src/components/OpenClawHub.tsx
+++ b/src/components/OpenClawHub.tsx
@@ -1,3 +1,15 @@
+/**
+ * OpenClaw Status Hub — main dashboard component.
+ *
+ * Renders 8 severity-colored cards (Project, Gateway, Channels, Skills,
+ * Memory, Cron, Docs, Changelog) with 4-level progressive disclosure:
+ * - L0 (Glance): card grid with severity dot + one-line summary
+ * - L1 (Hover): CSS tooltip with 3-5 detail lines
+ * - L2 (Click): card expands to show full metrics/lists
+ * - L3 (Panel): slide-in detail panel for docs/changelog deep-dive
+ *
+ * Accessible via the "Hub" tab or `mod+h` shortcut.
+ */
 import { useCallback, useMemo, useState } from "react";
 import type { OpenClawHubSnapshot } from "../../server/openclaw-hub-types";
 import { useOpenClawHub } from "../hooks/useOpenClawHub";

--- a/src/hooks/useOpenClawHub.ts
+++ b/src/hooks/useOpenClawHub.ts
@@ -1,3 +1,8 @@
+/**
+ * Polling hook for the OpenClaw Hub API.
+ * Fetches `/api/office/openclaw-hub` every 30 s and exposes snapshot/loading/error state.
+ * Requests are aborted on unmount or rapid re-fetch to prevent stale updates.
+ */
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { OpenClawHubSnapshot } from "../../server/openclaw-hub-types";
 

--- a/src/lib/openclaw-hub.ts
+++ b/src/lib/openclaw-hub.ts
@@ -1,3 +1,8 @@
+/**
+ * Frontend utilities for the OpenClaw Hub dashboard.
+ * Provides severity resolution, formatting helpers, and markdown parsing.
+ * @module openclaw-hub
+ */
 import type { OpenClawHubSnapshot } from "../../server/openclaw-hub-types";
 
 export type HubCardSeverity = "good" | "warn" | "bad" | "neutral";
@@ -12,6 +17,7 @@ export type HubCardId =
   | "docs"
   | "changelog";
 
+/** Map a hub card to its severity level based on current snapshot data. */
 export function resolveCardSeverity(
   snapshot: OpenClawHubSnapshot,
   cardId: HubCardId,
@@ -43,11 +49,13 @@ export function resolveCardSeverity(
   }
 }
 
+/** Format a "commits behind" count into a human-readable string. */
 export function formatCommitsBehind(n: number): string {
   if (n === 0) return "up to date";
   return `${n} commit${n === 1 ? "" : "s"} behind`;
 }
 
+/** Format a latency value (ms) for display, returning "-" when null. */
 export function formatLatencyMs(ms: number | null): string {
   if (ms === null) return "-";
   return `${ms}ms`;
@@ -58,6 +66,7 @@ export type MarkdownSection = {
   body: string;
 };
 
+/** Split markdown content into heading/body sections for structured rendering. */
 export function parseMarkdownToSections(content: string): MarkdownSection[] {
   const sections: MarkdownSection[] = [];
   const lines = content.split("\n");


### PR DESCRIPTION
## Summary
- Add JSDoc comments to all 7 new Hub files (types, server, utilities, hook, 3 components)
- Create `docs/openclaw-hub.md` — full technical documentation covering architecture, API spec, env vars, caching, file structure
- Update `README.md` — Hub feature, `mod+h` shortcut, 2 API endpoints, 2 env vars, docs link

## Changes
- `server/openclaw-hub-types.ts` — JSDoc on all 13 type definitions
- `server/openclaw-status.ts` — JSDoc on 3 exported functions
- `src/lib/openclaw-hub.ts` — module doc + JSDoc on 4 exported functions
- `src/hooks/useOpenClawHub.ts` — module doc describing polling behavior
- `src/components/OpenClawHub.tsx` — module doc with progressive disclosure overview
- `src/components/HubDetailPanel.tsx` — module doc + DetailTarget type doc
- `src/components/HubTooltip.tsx` — JSDoc on component and `tip` prop
- `docs/openclaw-hub.md` — NEW: comprehensive feature documentation
- `README.md` — updated with Hub references

## Test plan
- [x] TypeScript passes
- [x] ESLint passes
- [x] 141/141 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)