### PR TITLE
feat: add Dockerized runtime for OpenClawOffice

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+.env
+.env.*
+.env.local
+.env.*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:22-alpine
 
-RUN apk add --no-cache wget
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+RUN apk add --no-cache wget && corepack enable && corepack prepare pnpm@10 --activate
 
 WORKDIR /app
 
@@ -9,12 +8,14 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .
-RUN pnpm build
+RUN pnpm build && chown -R node:node /app
 
 ENV PORT=5179
 ENV OPENCLAW_STATE_DIR=/app/.openclaw
 ENV OPENCLAW_PROJECT_DIR=/app/openclaw
 ENV OPENCLAW_GATEWAY_PORT=18789
+
+USER node
 
 EXPOSE 5179
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,10 @@ services:
       - OPENCLAW_PROJECT_DIR=/app/openclaw
       - OPENCLAW_GATEWAY_PORT=18789
     volumes:
-      - ${HOME}/.openclaw:/app/.openclaw:ro
-      - ../openclaw:/app/openclaw:ro
+      - ${HOME:-/root}/.openclaw:/app/.openclaw:ro
+      - ${OPENCLAW_PROJECT_HOST_DIR:-../openclaw}:/app/openclaw:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5179/api/office/snapshot"]


### PR DESCRIPTION
## Summary
- add containerized runtime assets (`Dockerfile`, `docker-compose.yml`, `.dockerignore`) for OpenClawOffice
- expose the Office app on `127.0.0.1:5179` with health checks and restart policy for stable local operations
- mount OpenClaw state/project directories as read-only volumes so the dashboard can run against live local data

## Validation
- rebuilt and launched with `docker-compose up -d --build`
- verified container health and endpoint responses on `http://127.0.0.1:5179/` and `/api/office/snapshot`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정**
  * Docker 배포 지원: 애플리케이션을 컨테이너 환경에서 실행하기 위한 Docker 빌드 및 배포 구성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->