### PR TITLE
chore: add PR Labeler and CodeQL workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,48 @@
+server:
+  - changed-files:
+      - any-glob-to-any-file: 'server/**/*'
+
+hooks:
+  - changed-files:
+      - any-glob-to-any-file: 'src/hooks/**/*'
+
+components:
+  - changed-files:
+      - any-glob-to-any-file: 'src/components/**/*'
+
+lib:
+  - changed-files:
+      - any-glob-to-any-file: 'src/lib/**/*'
+
+types:
+  - changed-files:
+      - any-glob-to-any-file: 'src/types/**/*'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.test.ts'
+          - '**/*.spec.ts'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'docs/**/*'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**/*'
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Dockerfile'
+          - 'docker-compose.yml'
+          - '.dockerignore'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'pnpm-lock.yaml'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: self-hosted
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with: { version: 10 }
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,46 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label PR
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Label PR by files changed
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true
+
+  size:
+    name: Label PR Size
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Label PR size
+        uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/XS'
+          xs_max_size: 10
+          s_label: 'size/S'
+          s_max_size: 100
+          m_label: 'size/M'
+          m_max_size: 500
+          l_label: 'size/L'
+          l_max_size: 1000
+          xl_label: 'size/XL'
+          fail_if_xl: false
+          message_if_xl: |
+            This PR is quite large. Consider breaking it into smaller PRs for easier review.


### PR DESCRIPTION
## Summary

openClawWorld에 있는 PR 자동화 워크플로우를 openClawOffice에 동일하게 추가합니다.

## 변경 내용

### `.github/labeler.yml`
PR 변경 파일 경로 → 자동 라벨 매핑:
- `server/**` → `server`
- `src/hooks/**` → `hooks`
- `src/components/**` → `components`
- `src/lib/**` → `lib`
- `src/types/**` → `types`
- `**/*.test.ts` → `tests`
- `Dockerfile`, `docker-compose.yml` → `docker`
- `package.json`, `pnpm-lock.yaml` → `dependencies`
- `.github/**` → `ci`

### `.github/workflows/labeler.yml`
- PR 파일 변경 라벨러 (`actions/labeler@v5`)
- PR 크기 라벨러 (`size/XS` ~ `size/XL`, 줄 수 기준)

### `.github/workflows/codeql.yml`
- 트리거: PR → main, push → main, 매주 월요일 06:00 KST
- TypeScript/JavaScript 정적 보안 분석 (`security-extended` 쿼리)
- 결과는 GitHub Security 탭에서 확인 가능

## Related Issues

N/A (openClawWorld 패리티)

## Checklist

- [x] Config files only — no logic changes
- [x] Labels pre-created on repo
- [x] Mirrors openClawWorld proven workflow structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 자동 레이블링 시스템 도입: 수정된 파일에 따라 PR에 자동으로 레이블 적용
* 코드 보안 분석 워크플로우 추가: 주간 및 푸시 시점에 자동 코드 분석 수행
* PR 크기 기반 자동 분류: PR 규모에 따른 자동 레이블링으로 리뷰 프로세스 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->