### PR TITLE
fix(ci): upgrade CodeQL action v3→v4 and remove pnpm cache

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,18 +39,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: pnpm
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
- Upgrade `github/codeql-action/{init,autobuild,analyze}` from `v3` to `v4` (v3 deprecated December 2026)
- Remove `cache: pnpm` from `setup-node` step — the pnpm store doesn't exist on the self-hosted macOS runner before CodeQL autobuild runs, causing a `Path Validation Error` that marked every CodeQL run as failed

## Issue
Fixes the two annotations reported on CodeQL run #12:
- ❌ `Path Validation Error: Path(s) specified in the action for caching do(es) not exist`
- ⚠️ `CodeQL Action v3 will be deprecated in December 2026`

## Local CI
- [x] actionlint passed
- [x] No functional code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)