### PR TITLE
fix: resolve CodeQL security alerts — TOCTOU race & trivial conditional

### DIFF
--- a/server/openclaw-status.ts
+++ b/server/openclaw-status.ts
@@ -246,9 +246,9 @@ async function loadDocSummaries(dir: string): Promise<OpenClawDocSummary[]> {
 
   const readMdSummary = async (filePath: string, relativePath: string) => {
     try {
-      const stat = await fs.stat(filePath);
       const fd = await fs.open(filePath, "r");
       try {
+        const stat = await fd.stat();
         const buf = Buffer.alloc(Math.min(DOC_HEAD_BYTES, stat.size));
         await fd.read(buf, 0, buf.length, 0);
         const content = buf.toString("utf-8");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1679,7 +1679,7 @@ function App() {
           className="workspace-tabpanel"
           hidden={activeWorkspaceTab !== "tokens"}
         >
-          {snapshot ? <TokenDashboard snapshot={snapshot} /> : null}
+          <TokenDashboard snapshot={snapshot} />
         </section>
       </section>
 


### PR DESCRIPTION
## Summary

- **server/openclaw-status.ts**: Fix TOCTOU (time-of-check/time-of-use) race condition in `readMdSummary`. Previously called `fs.stat()` then `fs.open()`, leaving a window where the file could change between check and use. Fixed by calling `fs.open()` first, then `fd.stat()` on the open file descriptor.
- **src/App.tsx**: Remove trivially-true conditional check on `snapshot`. The `if (!snapshot) { return ... }` guard at line 1142 ensures `snapshot` is always non-null beyond that point; the ternary `snapshot ? <TokenDashboard ...> : null` was redundant.

## Issues
Closes #197
Closes #196

## Local CI
- [x] lint passed
- [x] build passed
- [x] test passed (256 tests)

## Notes on #198 (js/http-to-file-access)
Alert #1 / Issue #198 (`scripts/ux-verify.mjs:52`) is a **false positive** — the script is an internal UX verification tool that intentionally writes API response snapshots to `output/ux-verify/` for diff-based regression testing. Will be dismissed separately via the CodeQL API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Tokens 탭에서 스냅샷이 없을 때도 TokenDashboard가 올바르게 렌더링되도록 개선되었습니다.

* **리팩토링**
  * 내부 파일 크기 조회 로직이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->