### PR TITLE
fix(docker): support node:25-alpine without corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:25-alpine
 
-RUN apk add --no-cache wget && corepack enable && corepack prepare pnpm@10 --activate
+RUN apk add --no-cache wget && npm install -g pnpm@10
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- replace `corepack` activation with explicit `npm install -g pnpm@10` in `Dockerfile`
- keep the existing Node 25 Alpine base image while avoiding missing-corepack failures

## Verification
- `docker compose -f docker-compose.yml up -d --build`
- `docker compose -f docker-compose.yml ps` shows `openclawoffice-web` healthy
- `curl http://127.0.0.1:5179/api/office/snapshot` returns 200 JSON

Closes #203