### PR TITLE
feat: bubble lane lifecycle with active stale-timeout (120 s) (#205)

### DIFF
--- a/src/components/OfficeStage.tsx
+++ b/src/components/OfficeStage.tsx
@@ -740,13 +740,12 @@ export function OfficeStage({
     const visibleIds = new Set(visiblePlacements.map(({ entity }) => entity.id));
     for (const { entity } of visiblePlacements) {
       if (
-        entity.status === "active" &&
         isStaleActive(entity.status, entity.lastUpdatedAt, nowMs) &&
         !staleActiveLoggedRef.current.has(entity.id)
       ) {
         staleActiveLoggedRef.current.add(entity.id);
         console.warn(
-          `[openClawOffice] stale-active: entity "${entity.id}" (${entity.label}) has not reported in >120 s — excluded from bubble lane`,
+          `[openClawOffice] stale-active: entity "${entity.id}" has not reported in >120 s — excluded from bubble lane`,
         );
       }
     }

--- a/src/lib/bubble-lanes.test.ts
+++ b/src/lib/bubble-lanes.test.ts
@@ -87,6 +87,16 @@ describe("hasNonStaleActiveEntity — overlay visibility regression tests", () =
       ),
     ).toBe(false);
   });
+
+  it("active + missing lastUpdatedAt → false (treated as stale)", () => {
+    expect(
+      hasNonStaleActiveEntity([{ status: "active", lastUpdatedAt: undefined }], NOW),
+    ).toBe(false);
+  });
+
+  it("empty entity list → false", () => {
+    expect(hasNonStaleActiveEntity([], NOW)).toBe(false);
+  });
 });
 
 describe("buildBubbleLaneLayout", () => {

--- a/src/lib/bubble-lanes.test.ts
+++ b/src/lib/bubble-lanes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildBubbleLaneLayout, type BubbleLaneCandidate } from "./bubble-lanes";
+import {
+  buildBubbleLaneLayout,
+  hasNonStaleActiveEntity,
+  isStaleActive,
+  BUBBLE_ACTIVE_STALE_TIMEOUT_MS,
+  type BubbleLaneCandidate,
+} from "./bubble-lanes";
 
 function baseCandidate(partial: Partial<BubbleLaneCandidate> & {
   id: string;
@@ -19,6 +25,69 @@ function baseCandidate(partial: Partial<BubbleLaneCandidate> & {
     isExpanded: partial.isExpanded ?? false,
   };
 }
+
+const NOW = 1_700_000_000_000;
+
+describe("isStaleActive", () => {
+  it("returns false for non-active statuses regardless of age", () => {
+    expect(isStaleActive("idle", NOW - 200_000, NOW)).toBe(false);
+    expect(isStaleActive("error", NOW - 200_000, NOW)).toBe(false);
+    expect(isStaleActive("offline", NOW - 200_000, NOW)).toBe(false);
+    expect(isStaleActive("ok", NOW - 200_000, NOW)).toBe(false);
+  });
+
+  it("returns false for active entity with fresh heartbeat (<= 120 s)", () => {
+    expect(isStaleActive("active", NOW - 60_000, NOW)).toBe(false);
+    expect(isStaleActive("active", NOW - BUBBLE_ACTIVE_STALE_TIMEOUT_MS, NOW)).toBe(false);
+  });
+
+  it("returns true for active entity with stale heartbeat (> 120 s)", () => {
+    expect(isStaleActive("active", NOW - (BUBBLE_ACTIVE_STALE_TIMEOUT_MS + 1), NOW)).toBe(true);
+    expect(isStaleActive("active", NOW - 200_000, NOW)).toBe(true);
+  });
+
+  it("returns true for active entity with unknown lastUpdatedAt", () => {
+    expect(isStaleActive("active", undefined, NOW)).toBe(true);
+  });
+});
+
+describe("hasNonStaleActiveEntity — overlay visibility regression tests", () => {
+  it("active + fresh update (<= 120 s) → true (overlay visible)", () => {
+    expect(
+      hasNonStaleActiveEntity([{ status: "active", lastUpdatedAt: NOW - 60_000 }], NOW),
+    ).toBe(true);
+  });
+
+  it("active + stale (> 120 s) → false (overlay hidden)", () => {
+    expect(
+      hasNonStaleActiveEntity([{ status: "active", lastUpdatedAt: NOW - 200_000 }], NOW),
+    ).toBe(false);
+  });
+
+  it("2 active (1 stale + 1 fresh) → true (overlay visible)", () => {
+    expect(
+      hasNonStaleActiveEntity(
+        [
+          { status: "active", lastUpdatedAt: NOW - 200_000 }, // stale
+          { status: "active", lastUpdatedAt: NOW - 60_000 }, // fresh
+        ],
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("no active entities → false (overlay hidden)", () => {
+    expect(
+      hasNonStaleActiveEntity(
+        [
+          { status: "idle", lastUpdatedAt: NOW - 10_000 },
+          { status: "error", lastUpdatedAt: NOW - 5_000 },
+        ],
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
 
 describe("buildBubbleLaneLayout", () => {
   it("avoids overlap by spreading cards across rows", () => {


### PR DESCRIPTION
## Summary

- `isStaleActive(status, lastUpdatedAt, nowMs)` — pure function that returns `true` when an entity is `"active"` but its heartbeat is older than 120 s (or `lastUpdatedAt` is unknown)
- `hasNonStaleActiveEntity(entities, nowMs)` — overlay visibility gate; returns `true` when at least one non-stale active entity exists
- `OfficeStage`: stale-active entities are excluded from `bubbleLaneCandidates`; the `bubble-lane-overlay` section is only rendered when `hasNonStaleActive` is true
- Stale transitions are logged once per entity per visibility cycle via `useEffect` + `useRef<Set<string>>`
- `BUBBLE_ACTIVE_STALE_TIMEOUT_MS = 120_000` exported for tests and external reference

## Issue

Closes #205

## Local CI

- [x] actionlint passed
- [x] lint + format passed
- [x] build passed
- [x] test passed (264 tests, +8 new regression tests)

## Test plan

- `isStaleActive`: non-active statuses always false; active + fresh (≤120 s) → false; active + stale (>120 s) → true; active + missing `lastUpdatedAt` → true
- `hasNonStaleActiveEntity`: 4 TDD scenarios — fresh, stale, mixed, no-active
- `buildBubbleLaneLayout`: existing 3 tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 오래된 활성 엔티티의 표시 가시성이 개선되어 최신 데이터만 화면에 표시됩니다.
- 엔티티 상태 모니터링 및 진단 로깅이 강화되었습니다.

## 테스트
- 엔티티 신선도 검증을 위한 테스트 커버리지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->