### PR TITLE
fix: gracefully handle read-only state dir in Docker replay persistence (#210)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,11 @@ services:
       - OPENCLAW_STATE_DIR=/app/.openclaw
       - OPENCLAW_PROJECT_DIR=/app/openclaw
       - OPENCLAW_GATEWAY_PORT=18789
+      - OPENCLAW_REPLAY_DIR=/app/.replay-data
     volumes:
       - ${HOME:-/root}/.openclaw:/app/.openclaw:ro
       - ${OPENCLAW_PROJECT_HOST_DIR:-../openclaw}:/app/openclaw:ro
+      - openclawoffice_replay:/app/.replay-data
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped
@@ -23,3 +25,6 @@ services:
       timeout: 10s
       retries: 3
       start_period: 20s
+
+volumes:
+  openclawoffice_replay:

--- a/server/snapshot-store.test.ts
+++ b/server/snapshot-store.test.ts
@@ -261,7 +261,15 @@ describe("OfficeSnapshotStore — read-only filesystem handling (#210)", () => {
         makeSnapshot(Date.now(), { runId: "r-erofs", childAgentId: "ca", parentAgentId: "pa" }),
       );
       expect(result).toBeDefined();
+      expect(result.stored).toBe(false);
       expect(store.isPersistenceDisabled()).toBe(true);
+
+      // Second call must return immediately without touching the filesystem
+      const result2 = await store.persistSnapshot(
+        makeSnapshot(Date.now() + 1_000, { runId: "r-erofs-2", childAgentId: "ca", parentAgentId: "pa" }),
+      );
+      expect(result2.stored).toBe(false);
+      expect(result2.reason).toBe("disabled");
     } finally {
       mkdirSpy.mockRestore();
     }

--- a/server/vite-office-plugin.ts
+++ b/server/vite-office-plugin.ts
@@ -110,7 +110,10 @@ const replayStoreMetrics: ReplayStoreMetric = {
 
 function resolveSnapshotStore(stateDir: string): OfficeSnapshotStore {
   if (!snapshotStore) {
-    snapshotStore = OfficeSnapshotStore.forStateDir(stateDir);
+    const replayDir = process.env.OPENCLAW_REPLAY_DIR?.trim();
+    snapshotStore = replayDir
+      ? OfficeSnapshotStore.forReplayDir(replayDir)
+      : OfficeSnapshotStore.forStateDir(stateDir);
   }
   return snapshotStore;
 }


### PR DESCRIPTION
## Summary

- Add `OPENCLAW_REPLAY_DIR` env var: when set, replay data is written to a dedicated writable directory separate from the read-only `OPENCLAW_STATE_DIR` mount
- `OfficeSnapshotStore.forReplayDir(dir)` static factory for explicit replay directory
- `ensureRootDir()` catches `EROFS`/`EACCES`/`EPERM` and **disables persistence once** with a single `info` log — no more repeated warnings
- `persistSnapshot()` checks `persistenceDisabled` flag before each I/O call
- `docker-compose.yml`: adds `OPENCLAW_REPLAY_DIR=/app/.replay-data` env and `openclawoffice_replay` named volume (writable)

## Issue

Closes #210

## Local CI

- [x] actionlint passed
- [x] lint passed
- [x] build passed
- [x] test passed (269 tests, +3 new)

## Test plan

- `forReplayDir` creates a working store in the given directory
- `isPersistenceDisabled` is false for normal writable stores
- EROFS simulation via `vi.spyOn(fs, "mkdir")` — store disables gracefully, no throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 재생 데이터를 위한 전용 디렉토리 지원 추가

* **버그 수정**
  * 읽기 전용 파일시스템에서의 우아한 오류 처리 개선
  * 파일시스템 쓰기 실패 시 안정성 강화

* **테스트**
  * 읽기 전용 파일시스템 시나리오에 대한 포괄적 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->