### PR TITLE
feat: bubble lane overflow strategy for 3+ active entities (#207)

### DIFF
--- a/src/lib/stage-lod.test.ts
+++ b/src/lib/stage-lod.test.ts
@@ -83,6 +83,7 @@ describe("stage LOD helpers", () => {
           isExpanded: false,
           isSummary: false,
           hiddenCount: 0,
+          isActiveOverflow: false,
         },
         {
           id: "card:b",
@@ -99,6 +100,7 @@ describe("stage LOD helpers", () => {
           isExpanded: false,
           isSummary: true,
           hiddenCount: 2,
+          isActiveOverflow: false,
         },
       ],
       contentHeight: 220,


### PR DESCRIPTION
## Summary
- Add priority-based visibility limits when multiple entities are simultaneously active
- 1-2 active: existing layout unchanged (no regression)
- 3-4 active: `effectiveMaxVisible = 2`, summary card shows `+N more active`
- 5+   active: `effectiveMaxVisible = 1`, summary card shows `+N more active`
- Active-overflow summary cards are interactive (clickable, keyboard-accessible)
- On-demand expandable panel lists all active threads sorted by priority
- Panel closes via ESC key, Close button, or when active count naturally drops below 3
- Preserves `#206` stale-timeout (120 s) behavior with no regression

## Issue
Closes #207

## Local CI
- [x] lint passed
- [x] format:check passed
- [x] build passed (TypeScript + Vite)
- [x] test passed (269 tests, +3 new active-overflow tests)

## Test plan
- With 1-2 active subagents: cards render individually, no summary card
- With 3-4 active subagents: summary card "+N more active" appears; clicking opens panel with full list
- With 5+ active subagents: only 1 card per lane visible; panel lists all entries
- ESC key closes the panel
- Existing stale-timeout (120 s) behavior unchanged — stale entities still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)